### PR TITLE
update domain pojos to be based on latest code generation.

### DIFF
--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/Nsp10DomainConstants.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/Nsp10DomainConstants.java
@@ -31,13 +31,13 @@ import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
 // Start of user code imports
 // End of user code
 
-public interface DctermsDomainConstants
+public interface Nsp10DomainConstants
 {
     // Start of user code user constants
     // End of user code
 
-    public static String DUBLIN_CORE_DOMAIN = "http://purl.org/dc/terms/";
-    public static String DUBLIN_CORE_NAMSPACE = "http://purl.org/dc/terms/";
-    public static String DUBLIN_CORE_NAMSPACE_PREFIX = "dcterms";
+    public static String MATLAB_DOMAIN_DOMAIN = "http://your.organisation.domain/nsp10#";
+    public static String MATLAB_DOMAIN_NAMSPACE = "http://your.organisation.domain/nsp10#";
+    public static String MATLAB_DOMAIN_NAMSPACE_PREFIX = "nsp10";
 
 }

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/Person.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/Person.java
@@ -157,11 +157,13 @@ public class Person
         return result;
     }
     
+    @Deprecated
     public String toHtml()
     {
         return toHtml(false);
     }
     
+    @Deprecated
     public String toHtml(boolean asLocalResource)
     {
         String result = "";
@@ -267,6 +269,7 @@ public class Person
     }
     
     
+    @Deprecated
     static public String familyNameToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -286,6 +289,7 @@ public class Person
         return s;
     }
     
+    @Deprecated
     static public String givenNameToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -305,6 +309,7 @@ public class Person
         return s;
     }
     
+    @Deprecated
     static public String nameToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -325,6 +330,7 @@ public class Person
     }
     
     
+    @Deprecated
     public String familyNameToHtml()
     {
         String s = "";
@@ -349,6 +355,7 @@ public class Person
         return s;
     }
     
+    @Deprecated
     public String givenNameToHtml()
     {
         String s = "";
@@ -373,6 +380,7 @@ public class Person
         return s;
     }
     
+    @Deprecated
     public String nameToHtml()
     {
         String s = "";

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/ProvDomainConstants.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/ProvDomainConstants.java
@@ -40,8 +40,4 @@ public interface ProvDomainConstants
     public static String PROVENANCE_NAMSPACE = "http://www.w3.org/ns/prov#";
     public static String PROVENANCE_NAMSPACE_PREFIX = "prov";
 
-    public static String RESOURCESHAPE1_PATH = "resourceShape1";
-    public static String RESOURCESHAPE1_NAMESPACE = PROVENANCE_NAMSPACE; //namespace of the rdfs:class the resource describes
-    public static String RESOURCESHAPE1_LOCALNAME = "ResourceShape1"; //localName of the rdfs:class the resource describes
-    public static String RESOURCESHAPE1_TYPE = RESOURCESHAPE1_NAMESPACE + RESOURCESHAPE1_LOCALNAME; //fullname of the rdfs:class the resource describes
 }

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/RdfDomainConstants.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/RdfDomainConstants.java
@@ -40,8 +40,4 @@ public interface RdfDomainConstants
     public static String RDF_NAMSPACE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
     public static String RDF_NAMSPACE_PREFIX = "rdf";
 
-    public static String RDFSHAPE_PATH = "rDFSHape";
-    public static String RDFSHAPE_NAMESPACE = RDF_NAMSPACE; //namespace of the rdfs:class the resource describes
-    public static String RDFSHAPE_LOCALNAME = "RDFSHape"; //localName of the rdfs:class the resource describes
-    public static String RDFSHAPE_TYPE = RDFSHAPE_NAMESPACE + RDFSHAPE_LOCALNAME; //fullname of the rdfs:class the resource describes
 }

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/RdfsClass.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/RdfsClass.java
@@ -93,7 +93,7 @@ public class RdfsClass
 {
     // Start of user code attributeAnnotation:subClassOf
     // End of user code
-    private Link subClassOf = new Link();
+    private Link subClassOf;
     
     // Start of user code classAttributes
     // End of user code
@@ -152,11 +152,13 @@ public class RdfsClass
         return result;
     }
     
+    @Deprecated
     public String toHtml()
     {
         return toHtml(false);
     }
     
+    @Deprecated
     public String toHtml(boolean asLocalResource)
     {
         String result = "";
@@ -209,6 +211,7 @@ public class RdfsClass
     }
     
     
+    @Deprecated
     static public String subClassOfToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -228,6 +231,7 @@ public class RdfsClass
     }
     
     
+    @Deprecated
     public String subClassOfToHtml()
     {
         String s = "";

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/RdfsDomainConstants.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/RdfsDomainConstants.java
@@ -40,8 +40,8 @@ public interface RdfsDomainConstants
     public static String RDFS_NAMSPACE = "http://www.w3.org/2000/01/rdf-schema#";
     public static String RDFS_NAMSPACE_PREFIX = "rdfs";
 
-    public static String CLASS_PATH = "rdfsClass";
+    public static String CLASS_PATH = "class";
     public static String CLASS_NAMESPACE = RDFS_NAMSPACE; //namespace of the rdfs:class the resource describes
-    public static String CLASS_LOCALNAME = "RdfsClass"; //localName of the rdfs:class the resource describes
+    public static String CLASS_LOCALNAME = "Class"; //localName of the rdfs:class the resource describes
     public static String CLASS_TYPE = CLASS_NAMESPACE + CLASS_LOCALNAME; //fullname of the rdfs:class the resource describes
 }

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/ILinkType.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/ILinkType.java
@@ -92,7 +92,7 @@ public interface ILinkType
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor();
+    public Set<Link> getContributor();
 
     @OslcName("created")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "created")
@@ -109,7 +109,7 @@ public interface ILinkType
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator();
+    public Set<Link> getCreator();
 
     @OslcName("identifier")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "identifier")
@@ -139,7 +139,7 @@ public interface ILinkType
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider();
+    public Set<URI> getServiceProvider();
 
     @OslcName("comment")
     @OslcPropertyDefinition(RdfsDomainConstants.RDFS_NAMSPACE + "comment")
@@ -157,13 +157,13 @@ public interface ILinkType
     public String getLabel();
 
 
-    public void setContributor(final HashSet<Link> contributor );
+    public void setContributor(final Set<Link> contributor );
     public void setCreated(final Date created );
-    public void setCreator(final HashSet<Link> creator );
+    public void setCreator(final Set<Link> creator );
     public void setIdentifier(final String identifier );
     public void setModified(final Date modified );
     public void setInstanceShape(final URI instanceShape );
-    public void setServiceProvider(final HashSet<URI> serviceProvider );
+    public void setServiceProvider(final Set<URI> serviceProvider );
     public void setComment(final String comment );
     public void setLabel(final String label );
 }

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/IResource.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/IResource.java
@@ -92,7 +92,7 @@ public interface IResource
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor();
+    public Set<Link> getContributor();
 
     @OslcName("created")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "created")
@@ -109,7 +109,7 @@ public interface IResource
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator();
+    public Set<Link> getCreator();
 
     @OslcName("description")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "description")
@@ -154,7 +154,7 @@ public interface IResource
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.String)
     @OslcReadOnly(false)
-    public HashSet<String> getType();
+    public Set<String> getType();
 
     @OslcName("instanceShape")
     @OslcPropertyDefinition(OslcDomainConstants.OSLC_NAMSPACE + "instanceShape")
@@ -168,7 +168,7 @@ public interface IResource
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider();
+    public Set<URI> getServiceProvider();
 
     @OslcName("shortTitle")
     @OslcPropertyDefinition(OslcDomainConstants.OSLC_NAMSPACE + "shortTitle")
@@ -179,17 +179,17 @@ public interface IResource
     public String getShortTitle();
 
 
-    public void setContributor(final HashSet<Link> contributor );
+    public void setContributor(final Set<Link> contributor );
     public void setCreated(final Date created );
-    public void setCreator(final HashSet<Link> creator );
+    public void setCreator(final Set<Link> creator );
     public void setDescription(final String description );
     public void setIdentifier(final String identifier );
     public void setModified(final Date modified );
     public void setSource(final URI source );
     public void setTitle(final String title );
-    public void setType(final HashSet<String> type );
+    public void setType(final Set<String> type );
     public void setInstanceShape(final URI instanceShape );
-    public void setServiceProvider(final HashSet<URI> serviceProvider );
+    public void setServiceProvider(final Set<URI> serviceProvider );
     public void setShortTitle(final String shortTitle );
 }
 

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/LinkType.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/LinkType.java
@@ -97,13 +97,13 @@ public class LinkType
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private HashSet<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<Link>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private HashSet<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<Link>();
     // Start of user code attributeAnnotation:identifier
     // End of user code
     private String identifier;
@@ -115,7 +115,7 @@ public class LinkType
     private URI instanceShape;
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private HashSet<URI> serviceProvider = new HashSet<URI>();
+    private Set<URI> serviceProvider = new HashSet<URI>();
     // Start of user code attributeAnnotation:comment
     // End of user code
     private String comment;
@@ -180,11 +180,13 @@ public class LinkType
         return result;
     }
     
+    @Deprecated
     public String toHtml()
     {
         return toHtml(false);
     }
     
+    @Deprecated
     public String toHtml(boolean asLocalResource)
     {
         String result = "";
@@ -231,7 +233,7 @@ public class LinkType
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor()
+    public Set<Link> getContributor()
     {
         // Start of user code getterInit:contributor
         // End of user code
@@ -262,7 +264,7 @@ public class LinkType
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator()
+    public Set<Link> getCreator()
     {
         // Start of user code getterInit:creator
         // End of user code
@@ -320,7 +322,7 @@ public class LinkType
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider()
+    public Set<URI> getServiceProvider()
     {
         // Start of user code getterInit:serviceProvider
         // End of user code
@@ -359,7 +361,7 @@ public class LinkType
     
     // Start of user code setterAnnotation:contributor
     // End of user code
-    public void setContributor(final HashSet<Link> contributor )
+    public void setContributor(final Set<Link> contributor )
     {
         // Start of user code setterInit:contributor
         // End of user code
@@ -387,7 +389,7 @@ public class LinkType
     
     // Start of user code setterAnnotation:creator
     // End of user code
-    public void setCreator(final HashSet<Link> creator )
+    public void setCreator(final Set<Link> creator )
     {
         // Start of user code setterInit:creator
         // End of user code
@@ -439,7 +441,7 @@ public class LinkType
     
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
-    public void setServiceProvider(final HashSet<URI> serviceProvider )
+    public void setServiceProvider(final Set<URI> serviceProvider )
     {
         // Start of user code setterInit:serviceProvider
         // End of user code
@@ -478,6 +480,7 @@ public class LinkType
     }
     
     
+    @Deprecated
     static public String contributorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -496,6 +499,7 @@ public class LinkType
         return s;
     }
     
+    @Deprecated
     static public String createdToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -515,6 +519,7 @@ public class LinkType
         return s;
     }
     
+    @Deprecated
     static public String creatorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -533,6 +538,7 @@ public class LinkType
         return s;
     }
     
+    @Deprecated
     static public String identifierToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -552,6 +558,7 @@ public class LinkType
         return s;
     }
     
+    @Deprecated
     static public String modifiedToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -571,6 +578,7 @@ public class LinkType
         return s;
     }
     
+    @Deprecated
     static public String instanceShapeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -590,6 +598,7 @@ public class LinkType
         return s;
     }
     
+    @Deprecated
     static public String serviceProviderToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -609,6 +618,7 @@ public class LinkType
         return s;
     }
     
+    @Deprecated
     static public String commentToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -628,6 +638,7 @@ public class LinkType
         return s;
     }
     
+    @Deprecated
     static public String labelToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -648,6 +659,7 @@ public class LinkType
     }
     
     
+    @Deprecated
     public String contributorToHtml()
     {
         String s = "";
@@ -673,6 +685,7 @@ public class LinkType
         return s;
     }
     
+    @Deprecated
     public String createdToHtml()
     {
         String s = "";
@@ -697,6 +710,7 @@ public class LinkType
         return s;
     }
     
+    @Deprecated
     public String creatorToHtml()
     {
         String s = "";
@@ -722,6 +736,7 @@ public class LinkType
         return s;
     }
     
+    @Deprecated
     public String identifierToHtml()
     {
         String s = "";
@@ -746,6 +761,7 @@ public class LinkType
         return s;
     }
     
+    @Deprecated
     public String modifiedToHtml()
     {
         String s = "";
@@ -770,6 +786,7 @@ public class LinkType
         return s;
     }
     
+    @Deprecated
     public String instanceShapeToHtml()
     {
         String s = "";
@@ -794,6 +811,7 @@ public class LinkType
         return s;
     }
     
+    @Deprecated
     public String serviceProviderToHtml()
     {
         String s = "";
@@ -820,6 +838,7 @@ public class LinkType
         return s;
     }
     
+    @Deprecated
     public String commentToHtml()
     {
         String s = "";
@@ -844,6 +863,7 @@ public class LinkType
         return s;
     }
     
+    @Deprecated
     public String labelToHtml()
     {
         String s = "";

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/Resource.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/Resource.java
@@ -96,13 +96,13 @@ public class Resource
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private HashSet<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<Link>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private HashSet<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<Link>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -120,13 +120,13 @@ public class Resource
     private String title;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private HashSet<String> type = new HashSet<String>();
+    private Set<String> type = new HashSet<String>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
     private URI instanceShape;
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private HashSet<URI> serviceProvider = new HashSet<URI>();
+    private Set<URI> serviceProvider = new HashSet<URI>();
     // Start of user code attributeAnnotation:shortTitle
     // End of user code
     private String shortTitle;
@@ -188,11 +188,13 @@ public class Resource
         return result;
     }
     
+    @Deprecated
     public String toHtml()
     {
         return toHtml(false);
     }
     
+    @Deprecated
     public String toHtml(boolean asLocalResource)
     {
         String result = "";
@@ -244,7 +246,7 @@ public class Resource
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor()
+    public Set<Link> getContributor()
     {
         // Start of user code getterInit:contributor
         // End of user code
@@ -275,7 +277,7 @@ public class Resource
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator()
+    public Set<Link> getCreator()
     {
         // Start of user code getterInit:creator
         // End of user code
@@ -362,7 +364,7 @@ public class Resource
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.String)
     @OslcReadOnly(false)
-    public HashSet<String> getType()
+    public Set<String> getType()
     {
         // Start of user code getterInit:type
         // End of user code
@@ -390,7 +392,7 @@ public class Resource
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider()
+    public Set<URI> getServiceProvider()
     {
         // Start of user code getterInit:serviceProvider
         // End of user code
@@ -415,7 +417,7 @@ public class Resource
     
     // Start of user code setterAnnotation:contributor
     // End of user code
-    public void setContributor(final HashSet<Link> contributor )
+    public void setContributor(final Set<Link> contributor )
     {
         // Start of user code setterInit:contributor
         // End of user code
@@ -443,7 +445,7 @@ public class Resource
     
     // Start of user code setterAnnotation:creator
     // End of user code
-    public void setCreator(final HashSet<Link> creator )
+    public void setCreator(final Set<Link> creator )
     {
         // Start of user code setterInit:creator
         // End of user code
@@ -519,7 +521,7 @@ public class Resource
     
     // Start of user code setterAnnotation:type
     // End of user code
-    public void setType(final HashSet<String> type )
+    public void setType(final Set<String> type )
     {
         // Start of user code setterInit:type
         // End of user code
@@ -547,7 +549,7 @@ public class Resource
     
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
-    public void setServiceProvider(final HashSet<URI> serviceProvider )
+    public void setServiceProvider(final Set<URI> serviceProvider )
     {
         // Start of user code setterInit:serviceProvider
         // End of user code
@@ -574,6 +576,7 @@ public class Resource
     }
     
     
+    @Deprecated
     static public String contributorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -592,6 +595,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     static public String createdToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -611,6 +615,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     static public String creatorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -629,6 +634,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     static public String descriptionToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -648,6 +654,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     static public String identifierToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -667,6 +674,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     static public String modifiedToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -686,6 +694,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     static public String sourceToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -705,6 +714,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     static public String titleToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -724,6 +734,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     static public String typeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -743,6 +754,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     static public String instanceShapeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -762,6 +774,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     static public String serviceProviderToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -781,6 +794,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     static public String shortTitleToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -801,6 +815,7 @@ public class Resource
     }
     
     
+    @Deprecated
     public String contributorToHtml()
     {
         String s = "";
@@ -826,6 +841,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     public String createdToHtml()
     {
         String s = "";
@@ -850,6 +866,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     public String creatorToHtml()
     {
         String s = "";
@@ -875,6 +892,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     public String descriptionToHtml()
     {
         String s = "";
@@ -899,6 +917,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     public String identifierToHtml()
     {
         String s = "";
@@ -923,6 +942,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     public String modifiedToHtml()
     {
         String s = "";
@@ -947,6 +967,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     public String sourceToHtml()
     {
         String s = "";
@@ -971,6 +992,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     public String titleToHtml()
     {
         String s = "";
@@ -995,6 +1017,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     public String typeToHtml()
     {
         String s = "";
@@ -1021,6 +1044,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     public String instanceShapeToHtml()
     {
         String s = "";
@@ -1045,6 +1069,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     public String serviceProviderToHtml()
     {
         String s = "";
@@ -1071,6 +1096,7 @@ public class Resource
         return s;
     }
     
+    @Deprecated
     public String shortTitleToHtml()
     {
         String s = "";

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationPlan.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationPlan.java
@@ -98,13 +98,13 @@ public class AutomationPlan
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private HashSet<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<Link>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private HashSet<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<Link>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -116,10 +116,10 @@ public class AutomationPlan
     private Date modified;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private HashSet<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<Link>();
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private HashSet<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<String>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
@@ -128,16 +128,16 @@ public class AutomationPlan
     private URI instanceShape;
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private HashSet<URI> serviceProvider = new HashSet<URI>();
+    private Set<URI> serviceProvider = new HashSet<URI>();
     // Start of user code attributeAnnotation:parameterDefinition
     // End of user code
-    private HashSet<Link> parameterDefinition = new HashSet<Link>();
+    private Set<Link> parameterDefinition = new HashSet<Link>();
     // Start of user code attributeAnnotation:usesExecutionEnvironment
     // End of user code
-    private HashSet<Link> usesExecutionEnvironment = new HashSet<Link>();
+    private Set<Link> usesExecutionEnvironment = new HashSet<Link>();
     // Start of user code attributeAnnotation:futureAction
     // End of user code
-    private HashSet<Link> futureAction = new HashSet<Link>();
+    private Set<Link> futureAction = new HashSet<Link>();
     
     // Start of user code classAttributes
     // End of user code
@@ -196,11 +196,13 @@ public class AutomationPlan
         return result;
     }
     
+    @Deprecated
     public String toHtml()
     {
         return toHtml(false);
     }
     
+    @Deprecated
     public String toHtml(boolean asLocalResource)
     {
         String result = "";
@@ -272,7 +274,7 @@ public class AutomationPlan
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor()
+    public Set<Link> getContributor()
     {
         // Start of user code getterInit:contributor
         // End of user code
@@ -303,7 +305,7 @@ public class AutomationPlan
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator()
+    public Set<Link> getCreator()
     {
         // Start of user code getterInit:creator
         // End of user code
@@ -363,7 +365,7 @@ public class AutomationPlan
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType()
+    public Set<Link> getType()
     {
         // Start of user code getterInit:type
         // End of user code
@@ -379,7 +381,7 @@ public class AutomationPlan
     @OslcValueType(ValueType.String)
     @OslcReadOnly(false)
     @OslcTitle("")
-    public HashSet<String> getSubject()
+    public Set<String> getSubject()
     {
         // Start of user code getterInit:subject
         // End of user code
@@ -422,7 +424,7 @@ public class AutomationPlan
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider()
+    public Set<URI> getServiceProvider()
     {
         // Start of user code getterInit:serviceProvider
         // End of user code
@@ -437,7 +439,7 @@ public class AutomationPlan
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getParameterDefinition()
+    public Set<Link> getParameterDefinition()
     {
         // Start of user code getterInit:parameterDefinition
         // End of user code
@@ -453,7 +455,7 @@ public class AutomationPlan
     @OslcValueType(ValueType.Resource)
     @OslcRepresentation(Representation.Reference)
     @OslcReadOnly(false)
-    public HashSet<Link> getUsesExecutionEnvironment()
+    public Set<Link> getUsesExecutionEnvironment()
     {
         // Start of user code getterInit:usesExecutionEnvironment
         // End of user code
@@ -469,7 +471,7 @@ public class AutomationPlan
     @OslcValueType(ValueType.Resource)
     @OslcRepresentation(Representation.Reference)
     @OslcReadOnly(false)
-    public HashSet<Link> getFutureAction()
+    public Set<Link> getFutureAction()
     {
         // Start of user code getterInit:futureAction
         // End of user code
@@ -479,7 +481,7 @@ public class AutomationPlan
     
     // Start of user code setterAnnotation:contributor
     // End of user code
-    public void setContributor(final HashSet<Link> contributor )
+    public void setContributor(final Set<Link> contributor )
     {
         // Start of user code setterInit:contributor
         // End of user code
@@ -507,7 +509,7 @@ public class AutomationPlan
     
     // Start of user code setterAnnotation:creator
     // End of user code
-    public void setCreator(final HashSet<Link> creator )
+    public void setCreator(final Set<Link> creator )
     {
         // Start of user code setterInit:creator
         // End of user code
@@ -559,7 +561,7 @@ public class AutomationPlan
     
     // Start of user code setterAnnotation:type
     // End of user code
-    public void setType(final HashSet<Link> type )
+    public void setType(final Set<Link> type )
     {
         // Start of user code setterInit:type
         // End of user code
@@ -575,7 +577,7 @@ public class AutomationPlan
     
     // Start of user code setterAnnotation:subject
     // End of user code
-    public void setSubject(final HashSet<String> subject )
+    public void setSubject(final Set<String> subject )
     {
         // Start of user code setterInit:subject
         // End of user code
@@ -615,7 +617,7 @@ public class AutomationPlan
     
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
-    public void setServiceProvider(final HashSet<URI> serviceProvider )
+    public void setServiceProvider(final Set<URI> serviceProvider )
     {
         // Start of user code setterInit:serviceProvider
         // End of user code
@@ -631,7 +633,7 @@ public class AutomationPlan
     
     // Start of user code setterAnnotation:parameterDefinition
     // End of user code
-    public void setParameterDefinition(final HashSet<Link> parameterDefinition )
+    public void setParameterDefinition(final Set<Link> parameterDefinition )
     {
         // Start of user code setterInit:parameterDefinition
         // End of user code
@@ -647,7 +649,7 @@ public class AutomationPlan
     
     // Start of user code setterAnnotation:usesExecutionEnvironment
     // End of user code
-    public void setUsesExecutionEnvironment(final HashSet<Link> usesExecutionEnvironment )
+    public void setUsesExecutionEnvironment(final Set<Link> usesExecutionEnvironment )
     {
         // Start of user code setterInit:usesExecutionEnvironment
         // End of user code
@@ -663,7 +665,7 @@ public class AutomationPlan
     
     // Start of user code setterAnnotation:futureAction
     // End of user code
-    public void setFutureAction(final HashSet<Link> futureAction )
+    public void setFutureAction(final Set<Link> futureAction )
     {
         // Start of user code setterInit:futureAction
         // End of user code
@@ -678,6 +680,7 @@ public class AutomationPlan
     }
     
     
+    @Deprecated
     static public String contributorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -696,6 +699,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     static public String createdToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -715,6 +719,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     static public String creatorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -733,6 +738,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     static public String descriptionToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -752,6 +758,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     static public String identifierToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -771,6 +778,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     static public String modifiedToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -790,6 +798,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     static public String typeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -808,6 +817,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     static public String subjectToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -827,6 +837,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     static public String titleToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -846,6 +857,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     static public String instanceShapeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -865,6 +877,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     static public String serviceProviderToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -884,6 +897,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     static public String parameterDefinitionToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -902,6 +916,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     static public String usesExecutionEnvironmentToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -920,6 +935,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     static public String futureActionToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -939,6 +955,7 @@ public class AutomationPlan
     }
     
     
+    @Deprecated
     public String contributorToHtml()
     {
         String s = "";
@@ -964,6 +981,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     public String createdToHtml()
     {
         String s = "";
@@ -988,6 +1006,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     public String creatorToHtml()
     {
         String s = "";
@@ -1013,6 +1032,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     public String descriptionToHtml()
     {
         String s = "";
@@ -1037,6 +1057,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     public String identifierToHtml()
     {
         String s = "";
@@ -1061,6 +1082,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     public String modifiedToHtml()
     {
         String s = "";
@@ -1085,6 +1107,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     public String typeToHtml()
     {
         String s = "";
@@ -1115,6 +1138,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     public String subjectToHtml()
     {
         String s = "";
@@ -1141,6 +1165,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     public String titleToHtml()
     {
         String s = "";
@@ -1165,6 +1190,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     public String instanceShapeToHtml()
     {
         String s = "";
@@ -1189,6 +1215,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     public String serviceProviderToHtml()
     {
         String s = "";
@@ -1215,6 +1242,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     public String parameterDefinitionToHtml()
     {
         String s = "";
@@ -1245,6 +1273,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     public String usesExecutionEnvironmentToHtml()
     {
         String s = "";
@@ -1275,6 +1304,7 @@ public class AutomationPlan
         return s;
     }
     
+    @Deprecated
     public String futureActionToHtml()
     {
         String s = "";

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationRequest.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationRequest.java
@@ -100,13 +100,13 @@ public class AutomationRequest
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private HashSet<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<Link>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private HashSet<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<Link>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -118,7 +118,7 @@ public class AutomationRequest
     private Date modified;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private HashSet<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<Link>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
@@ -127,19 +127,19 @@ public class AutomationRequest
     private URI instanceShape;
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private HashSet<URI> serviceProvider = new HashSet<URI>();
+    private Set<URI> serviceProvider = new HashSet<URI>();
     // Start of user code attributeAnnotation:state
     // End of user code
-    private HashSet<Link> state = new HashSet<Link>();
+    private Set<Link> state = new HashSet<Link>();
     // Start of user code attributeAnnotation:desiredState
     // End of user code
-    private Link desiredState = new Link();
+    private Link desiredState;
     // Start of user code attributeAnnotation:inputParameter
     // End of user code
-    private HashSet<Link> inputParameter = new HashSet<Link>();
+    private Set<Link> inputParameter = new HashSet<Link>();
     // Start of user code attributeAnnotation:executesAutomationPlan
     // End of user code
-    private Link executesAutomationPlan = new Link();
+    private Link executesAutomationPlan;
     
     // Start of user code classAttributes
     // End of user code
@@ -198,11 +198,13 @@ public class AutomationRequest
         return result;
     }
     
+    @Deprecated
     public String toHtml()
     {
         return toHtml(false);
     }
     
+    @Deprecated
     public String toHtml(boolean asLocalResource)
     {
         String result = "";
@@ -264,7 +266,7 @@ public class AutomationRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor()
+    public Set<Link> getContributor()
     {
         // Start of user code getterInit:contributor
         // End of user code
@@ -295,7 +297,7 @@ public class AutomationRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator()
+    public Set<Link> getCreator()
     {
         // Start of user code getterInit:creator
         // End of user code
@@ -355,7 +357,7 @@ public class AutomationRequest
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType()
+    public Set<Link> getType()
     {
         // Start of user code getterInit:type
         // End of user code
@@ -398,7 +400,7 @@ public class AutomationRequest
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider()
+    public Set<URI> getServiceProvider()
     {
         // Start of user code getterInit:serviceProvider
         // End of user code
@@ -413,7 +415,7 @@ public class AutomationRequest
     @OslcOccurs(Occurs.OneOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(true)
-    public HashSet<Link> getState()
+    public Set<Link> getState()
     {
         // Start of user code getterInit:state
         // End of user code
@@ -444,7 +446,7 @@ public class AutomationRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_autoDomainConstants.PARAMETERINSTANCE_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getInputParameter()
+    public Set<Link> getInputParameter()
     {
         // Start of user code getterInit:inputParameter
         // End of user code
@@ -471,7 +473,7 @@ public class AutomationRequest
     
     // Start of user code setterAnnotation:contributor
     // End of user code
-    public void setContributor(final HashSet<Link> contributor )
+    public void setContributor(final Set<Link> contributor )
     {
         // Start of user code setterInit:contributor
         // End of user code
@@ -499,7 +501,7 @@ public class AutomationRequest
     
     // Start of user code setterAnnotation:creator
     // End of user code
-    public void setCreator(final HashSet<Link> creator )
+    public void setCreator(final Set<Link> creator )
     {
         // Start of user code setterInit:creator
         // End of user code
@@ -551,7 +553,7 @@ public class AutomationRequest
     
     // Start of user code setterAnnotation:type
     // End of user code
-    public void setType(final HashSet<Link> type )
+    public void setType(final Set<Link> type )
     {
         // Start of user code setterInit:type
         // End of user code
@@ -591,7 +593,7 @@ public class AutomationRequest
     
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
-    public void setServiceProvider(final HashSet<URI> serviceProvider )
+    public void setServiceProvider(final Set<URI> serviceProvider )
     {
         // Start of user code setterInit:serviceProvider
         // End of user code
@@ -607,7 +609,7 @@ public class AutomationRequest
     
     // Start of user code setterAnnotation:state
     // End of user code
-    public void setState(final HashSet<Link> state )
+    public void setState(final Set<Link> state )
     {
         // Start of user code setterInit:state
         // End of user code
@@ -635,7 +637,7 @@ public class AutomationRequest
     
     // Start of user code setterAnnotation:inputParameter
     // End of user code
-    public void setInputParameter(final HashSet<Link> inputParameter )
+    public void setInputParameter(final Set<Link> inputParameter )
     {
         // Start of user code setterInit:inputParameter
         // End of user code
@@ -662,6 +664,7 @@ public class AutomationRequest
     }
     
     
+    @Deprecated
     static public String contributorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -680,6 +683,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     static public String createdToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -699,6 +703,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     static public String creatorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -717,6 +722,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     static public String descriptionToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -736,6 +742,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     static public String identifierToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -755,6 +762,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     static public String modifiedToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -774,6 +782,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     static public String typeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -792,6 +801,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     static public String titleToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -811,6 +821,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     static public String instanceShapeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -830,6 +841,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     static public String serviceProviderToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -849,6 +861,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     static public String stateToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -867,6 +880,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     static public String desiredStateToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -885,6 +899,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     static public String inputParameterToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -903,6 +918,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     static public String executesAutomationPlanToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -922,6 +938,7 @@ public class AutomationRequest
     }
     
     
+    @Deprecated
     public String contributorToHtml()
     {
         String s = "";
@@ -947,6 +964,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     public String createdToHtml()
     {
         String s = "";
@@ -971,6 +989,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     public String creatorToHtml()
     {
         String s = "";
@@ -996,6 +1015,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     public String descriptionToHtml()
     {
         String s = "";
@@ -1020,6 +1040,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     public String identifierToHtml()
     {
         String s = "";
@@ -1044,6 +1065,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     public String modifiedToHtml()
     {
         String s = "";
@@ -1068,6 +1090,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     public String typeToHtml()
     {
         String s = "";
@@ -1098,6 +1121,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     public String titleToHtml()
     {
         String s = "";
@@ -1122,6 +1146,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     public String instanceShapeToHtml()
     {
         String s = "";
@@ -1146,6 +1171,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     public String serviceProviderToHtml()
     {
         String s = "";
@@ -1172,6 +1198,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     public String stateToHtml()
     {
         String s = "";
@@ -1202,6 +1229,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     public String desiredStateToHtml()
     {
         String s = "";
@@ -1226,6 +1254,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     public String inputParameterToHtml()
     {
         String s = "";
@@ -1251,6 +1280,7 @@ public class AutomationRequest
         return s;
     }
     
+    @Deprecated
     public String executesAutomationPlanToHtml()
     {
         String s = "";

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationResult.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationResult.java
@@ -102,13 +102,13 @@ public class AutomationResult
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private HashSet<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<Link>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private HashSet<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<Link>();
     // Start of user code attributeAnnotation:identifier
     // End of user code
     private String identifier;
@@ -117,10 +117,10 @@ public class AutomationResult
     private Date modified;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private HashSet<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<Link>();
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private HashSet<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<String>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
@@ -129,31 +129,31 @@ public class AutomationResult
     private URI instanceShape;
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private HashSet<URI> serviceProvider = new HashSet<URI>();
+    private Set<URI> serviceProvider = new HashSet<URI>();
     // Start of user code attributeAnnotation:state
     // End of user code
-    private HashSet<Link> state = new HashSet<Link>();
+    private Set<Link> state = new HashSet<Link>();
     // Start of user code attributeAnnotation:desiredState
     // End of user code
-    private Link desiredState = new Link();
+    private Link desiredState;
     // Start of user code attributeAnnotation:verdict
     // End of user code
-    private HashSet<Link> verdict = new HashSet<Link>();
+    private Set<Link> verdict = new HashSet<Link>();
     // Start of user code attributeAnnotation:contribution
     // End of user code
-    private HashSet<Link> contribution = new HashSet<Link>();
+    private Set<Link> contribution = new HashSet<Link>();
     // Start of user code attributeAnnotation:inputParameter
     // End of user code
-    private HashSet<Link> inputParameter = new HashSet<Link>();
+    private Set<Link> inputParameter = new HashSet<Link>();
     // Start of user code attributeAnnotation:outputParameter
     // End of user code
-    private HashSet<Link> outputParameter = new HashSet<Link>();
+    private Set<Link> outputParameter = new HashSet<Link>();
     // Start of user code attributeAnnotation:producedByAutomationRequest
     // End of user code
-    private Link producedByAutomationRequest = new Link();
+    private Link producedByAutomationRequest;
     // Start of user code attributeAnnotation:reportsOnAutomationPlan
     // End of user code
-    private Link reportsOnAutomationPlan = new Link();
+    private Link reportsOnAutomationPlan;
     
     // Start of user code classAttributes
     // End of user code
@@ -212,11 +212,13 @@ public class AutomationResult
         return result;
     }
     
+    @Deprecated
     public String toHtml()
     {
         return toHtml(false);
     }
     
+    @Deprecated
     public String toHtml(boolean asLocalResource)
     {
         String result = "";
@@ -298,7 +300,7 @@ public class AutomationResult
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor()
+    public Set<Link> getContributor()
     {
         // Start of user code getterInit:contributor
         // End of user code
@@ -329,7 +331,7 @@ public class AutomationResult
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator()
+    public Set<Link> getCreator()
     {
         // Start of user code getterInit:creator
         // End of user code
@@ -374,7 +376,7 @@ public class AutomationResult
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType()
+    public Set<Link> getType()
     {
         // Start of user code getterInit:type
         // End of user code
@@ -390,7 +392,7 @@ public class AutomationResult
     @OslcValueType(ValueType.String)
     @OslcReadOnly(false)
     @OslcTitle("")
-    public HashSet<String> getSubject()
+    public Set<String> getSubject()
     {
         // Start of user code getterInit:subject
         // End of user code
@@ -433,7 +435,7 @@ public class AutomationResult
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider()
+    public Set<URI> getServiceProvider()
     {
         // Start of user code getterInit:serviceProvider
         // End of user code
@@ -448,7 +450,7 @@ public class AutomationResult
     @OslcOccurs(Occurs.OneOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(true)
-    public HashSet<Link> getState()
+    public Set<Link> getState()
     {
         // Start of user code getterInit:state
         // End of user code
@@ -478,7 +480,7 @@ public class AutomationResult
     @OslcOccurs(Occurs.OneOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getVerdict()
+    public Set<Link> getVerdict()
     {
         // Start of user code getterInit:verdict
         // End of user code
@@ -493,7 +495,7 @@ public class AutomationResult
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getContribution()
+    public Set<Link> getContribution()
     {
         // Start of user code getterInit:contribution
         // End of user code
@@ -509,7 +511,7 @@ public class AutomationResult
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_autoDomainConstants.PARAMETERINSTANCE_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getInputParameter()
+    public Set<Link> getInputParameter()
     {
         // Start of user code getterInit:inputParameter
         // End of user code
@@ -525,7 +527,7 @@ public class AutomationResult
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_autoDomainConstants.PARAMETERINSTANCE_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getOutputParameter()
+    public Set<Link> getOutputParameter()
     {
         // Start of user code getterInit:outputParameter
         // End of user code
@@ -569,7 +571,7 @@ public class AutomationResult
     
     // Start of user code setterAnnotation:contributor
     // End of user code
-    public void setContributor(final HashSet<Link> contributor )
+    public void setContributor(final Set<Link> contributor )
     {
         // Start of user code setterInit:contributor
         // End of user code
@@ -597,7 +599,7 @@ public class AutomationResult
     
     // Start of user code setterAnnotation:creator
     // End of user code
-    public void setCreator(final HashSet<Link> creator )
+    public void setCreator(final Set<Link> creator )
     {
         // Start of user code setterInit:creator
         // End of user code
@@ -637,7 +639,7 @@ public class AutomationResult
     
     // Start of user code setterAnnotation:type
     // End of user code
-    public void setType(final HashSet<Link> type )
+    public void setType(final Set<Link> type )
     {
         // Start of user code setterInit:type
         // End of user code
@@ -653,7 +655,7 @@ public class AutomationResult
     
     // Start of user code setterAnnotation:subject
     // End of user code
-    public void setSubject(final HashSet<String> subject )
+    public void setSubject(final Set<String> subject )
     {
         // Start of user code setterInit:subject
         // End of user code
@@ -693,7 +695,7 @@ public class AutomationResult
     
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
-    public void setServiceProvider(final HashSet<URI> serviceProvider )
+    public void setServiceProvider(final Set<URI> serviceProvider )
     {
         // Start of user code setterInit:serviceProvider
         // End of user code
@@ -709,7 +711,7 @@ public class AutomationResult
     
     // Start of user code setterAnnotation:state
     // End of user code
-    public void setState(final HashSet<Link> state )
+    public void setState(final Set<Link> state )
     {
         // Start of user code setterInit:state
         // End of user code
@@ -737,7 +739,7 @@ public class AutomationResult
     
     // Start of user code setterAnnotation:verdict
     // End of user code
-    public void setVerdict(final HashSet<Link> verdict )
+    public void setVerdict(final Set<Link> verdict )
     {
         // Start of user code setterInit:verdict
         // End of user code
@@ -753,7 +755,7 @@ public class AutomationResult
     
     // Start of user code setterAnnotation:contribution
     // End of user code
-    public void setContribution(final HashSet<Link> contribution )
+    public void setContribution(final Set<Link> contribution )
     {
         // Start of user code setterInit:contribution
         // End of user code
@@ -769,7 +771,7 @@ public class AutomationResult
     
     // Start of user code setterAnnotation:inputParameter
     // End of user code
-    public void setInputParameter(final HashSet<Link> inputParameter )
+    public void setInputParameter(final Set<Link> inputParameter )
     {
         // Start of user code setterInit:inputParameter
         // End of user code
@@ -785,7 +787,7 @@ public class AutomationResult
     
     // Start of user code setterAnnotation:outputParameter
     // End of user code
-    public void setOutputParameter(final HashSet<Link> outputParameter )
+    public void setOutputParameter(final Set<Link> outputParameter )
     {
         // Start of user code setterInit:outputParameter
         // End of user code
@@ -824,6 +826,7 @@ public class AutomationResult
     }
     
     
+    @Deprecated
     static public String contributorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -842,6 +845,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     static public String createdToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -861,6 +865,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     static public String creatorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -879,6 +884,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     static public String identifierToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -898,6 +904,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     static public String modifiedToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -917,6 +924,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     static public String typeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -935,6 +943,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     static public String subjectToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -954,6 +963,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     static public String titleToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -973,6 +983,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     static public String instanceShapeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -992,6 +1003,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     static public String serviceProviderToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1011,6 +1023,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     static public String stateToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1029,6 +1042,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     static public String desiredStateToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1047,6 +1061,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     static public String verdictToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1065,6 +1080,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     static public String contributionToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1083,6 +1099,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     static public String inputParameterToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1101,6 +1118,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     static public String outputParameterToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1119,6 +1137,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     static public String producedByAutomationRequestToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1137,6 +1156,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     static public String reportsOnAutomationPlanToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1156,6 +1176,7 @@ public class AutomationResult
     }
     
     
+    @Deprecated
     public String contributorToHtml()
     {
         String s = "";
@@ -1181,6 +1202,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     public String createdToHtml()
     {
         String s = "";
@@ -1205,6 +1227,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     public String creatorToHtml()
     {
         String s = "";
@@ -1230,6 +1253,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     public String identifierToHtml()
     {
         String s = "";
@@ -1254,6 +1278,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     public String modifiedToHtml()
     {
         String s = "";
@@ -1278,6 +1303,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     public String typeToHtml()
     {
         String s = "";
@@ -1308,6 +1334,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     public String subjectToHtml()
     {
         String s = "";
@@ -1334,6 +1361,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     public String titleToHtml()
     {
         String s = "";
@@ -1358,6 +1386,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     public String instanceShapeToHtml()
     {
         String s = "";
@@ -1382,6 +1411,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     public String serviceProviderToHtml()
     {
         String s = "";
@@ -1408,6 +1438,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     public String stateToHtml()
     {
         String s = "";
@@ -1438,6 +1469,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     public String desiredStateToHtml()
     {
         String s = "";
@@ -1462,6 +1494,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     public String verdictToHtml()
     {
         String s = "";
@@ -1492,6 +1525,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     public String contributionToHtml()
     {
         String s = "";
@@ -1522,6 +1556,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     public String inputParameterToHtml()
     {
         String s = "";
@@ -1547,6 +1582,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     public String outputParameterToHtml()
     {
         String s = "";
@@ -1572,6 +1608,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     public String producedByAutomationRequestToHtml()
     {
         String s = "";
@@ -1596,6 +1633,7 @@ public class AutomationResult
         return s;
     }
     
+    @Deprecated
     public String reportsOnAutomationPlanToHtml()
     {
         String s = "";

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/IAutomationPlan.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/IAutomationPlan.java
@@ -98,7 +98,7 @@ public interface IAutomationPlan
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor();
+    public Set<Link> getContributor();
 
     @OslcName("created")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "created")
@@ -115,7 +115,7 @@ public interface IAutomationPlan
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator();
+    public Set<Link> getCreator();
 
     @OslcName("description")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "description")
@@ -147,7 +147,7 @@ public interface IAutomationPlan
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType();
+    public Set<Link> getType();
 
     @OslcName("subject")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "subject")
@@ -156,7 +156,7 @@ public interface IAutomationPlan
     @OslcValueType(ValueType.String)
     @OslcReadOnly(false)
     @OslcTitle("")
-    public HashSet<String> getSubject();
+    public Set<String> getSubject();
 
     @OslcName("title")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "title")
@@ -178,7 +178,7 @@ public interface IAutomationPlan
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider();
+    public Set<URI> getServiceProvider();
 
     @OslcName("parameterDefinition")
     @OslcPropertyDefinition(Oslc_autoDomainConstants.AUTOMATION_NAMSPACE + "parameterDefinition")
@@ -186,7 +186,7 @@ public interface IAutomationPlan
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getParameterDefinition();
+    public Set<Link> getParameterDefinition();
 
     @OslcName("usesExecutionEnvironment")
     @OslcPropertyDefinition(Oslc_autoDomainConstants.AUTOMATION_NAMSPACE + "usesExecutionEnvironment")
@@ -195,7 +195,7 @@ public interface IAutomationPlan
     @OslcValueType(ValueType.Resource)
     @OslcRepresentation(Representation.Reference)
     @OslcReadOnly(false)
-    public HashSet<Link> getUsesExecutionEnvironment();
+    public Set<Link> getUsesExecutionEnvironment();
 
     @OslcName("futureAction")
     @OslcPropertyDefinition(Oslc_autoDomainConstants.AUTOMATION_NAMSPACE + "futureAction")
@@ -204,22 +204,22 @@ public interface IAutomationPlan
     @OslcValueType(ValueType.Resource)
     @OslcRepresentation(Representation.Reference)
     @OslcReadOnly(false)
-    public HashSet<Link> getFutureAction();
+    public Set<Link> getFutureAction();
 
 
-    public void setContributor(final HashSet<Link> contributor );
+    public void setContributor(final Set<Link> contributor );
     public void setCreated(final Date created );
-    public void setCreator(final HashSet<Link> creator );
+    public void setCreator(final Set<Link> creator );
     public void setDescription(final String description );
     public void setIdentifier(final String identifier );
     public void setModified(final Date modified );
-    public void setType(final HashSet<Link> type );
-    public void setSubject(final HashSet<String> subject );
+    public void setType(final Set<Link> type );
+    public void setSubject(final Set<String> subject );
     public void setTitle(final String title );
     public void setInstanceShape(final URI instanceShape );
-    public void setServiceProvider(final HashSet<URI> serviceProvider );
-    public void setParameterDefinition(final HashSet<Link> parameterDefinition );
-    public void setUsesExecutionEnvironment(final HashSet<Link> usesExecutionEnvironment );
-    public void setFutureAction(final HashSet<Link> futureAction );
+    public void setServiceProvider(final Set<URI> serviceProvider );
+    public void setParameterDefinition(final Set<Link> parameterDefinition );
+    public void setUsesExecutionEnvironment(final Set<Link> usesExecutionEnvironment );
+    public void setFutureAction(final Set<Link> futureAction );
 }
 

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/IAutomationRequest.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/IAutomationRequest.java
@@ -98,7 +98,7 @@ public interface IAutomationRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor();
+    public Set<Link> getContributor();
 
     @OslcName("created")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "created")
@@ -115,7 +115,7 @@ public interface IAutomationRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator();
+    public Set<Link> getCreator();
 
     @OslcName("description")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "description")
@@ -147,7 +147,7 @@ public interface IAutomationRequest
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType();
+    public Set<Link> getType();
 
     @OslcName("title")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "title")
@@ -169,7 +169,7 @@ public interface IAutomationRequest
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider();
+    public Set<URI> getServiceProvider();
 
     @OslcName("state")
     @OslcPropertyDefinition(Oslc_autoDomainConstants.AUTOMATION_NAMSPACE + "state")
@@ -177,7 +177,7 @@ public interface IAutomationRequest
     @OslcOccurs(Occurs.OneOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(true)
-    public HashSet<Link> getState();
+    public Set<Link> getState();
 
     @OslcName("desiredState")
     @OslcPropertyDefinition(Oslc_autoDomainConstants.AUTOMATION_NAMSPACE + "desiredState")
@@ -194,7 +194,7 @@ public interface IAutomationRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_autoDomainConstants.PARAMETERINSTANCE_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getInputParameter();
+    public Set<Link> getInputParameter();
 
     @OslcName("executesAutomationPlan")
     @OslcPropertyDefinition(Oslc_autoDomainConstants.AUTOMATION_NAMSPACE + "executesAutomationPlan")
@@ -207,19 +207,19 @@ public interface IAutomationRequest
     public Link getExecutesAutomationPlan();
 
 
-    public void setContributor(final HashSet<Link> contributor );
+    public void setContributor(final Set<Link> contributor );
     public void setCreated(final Date created );
-    public void setCreator(final HashSet<Link> creator );
+    public void setCreator(final Set<Link> creator );
     public void setDescription(final String description );
     public void setIdentifier(final String identifier );
     public void setModified(final Date modified );
-    public void setType(final HashSet<Link> type );
+    public void setType(final Set<Link> type );
     public void setTitle(final String title );
     public void setInstanceShape(final URI instanceShape );
-    public void setServiceProvider(final HashSet<URI> serviceProvider );
-    public void setState(final HashSet<Link> state );
+    public void setServiceProvider(final Set<URI> serviceProvider );
+    public void setState(final Set<Link> state );
     public void setDesiredState(final Link desiredState );
-    public void setInputParameter(final HashSet<Link> inputParameter );
+    public void setInputParameter(final Set<Link> inputParameter );
     public void setExecutesAutomationPlan(final Link executesAutomationPlan );
 }
 

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/IAutomationResult.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/IAutomationResult.java
@@ -104,7 +104,7 @@ public interface IAutomationResult
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor();
+    public Set<Link> getContributor();
 
     @OslcName("created")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "created")
@@ -121,7 +121,7 @@ public interface IAutomationResult
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator();
+    public Set<Link> getCreator();
 
     @OslcName("identifier")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "identifier")
@@ -145,7 +145,7 @@ public interface IAutomationResult
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType();
+    public Set<Link> getType();
 
     @OslcName("subject")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "subject")
@@ -154,7 +154,7 @@ public interface IAutomationResult
     @OslcValueType(ValueType.String)
     @OslcReadOnly(false)
     @OslcTitle("")
-    public HashSet<String> getSubject();
+    public Set<String> getSubject();
 
     @OslcName("title")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "title")
@@ -176,7 +176,7 @@ public interface IAutomationResult
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider();
+    public Set<URI> getServiceProvider();
 
     @OslcName("state")
     @OslcPropertyDefinition(Oslc_autoDomainConstants.AUTOMATION_NAMSPACE + "state")
@@ -184,7 +184,7 @@ public interface IAutomationResult
     @OslcOccurs(Occurs.OneOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(true)
-    public HashSet<Link> getState();
+    public Set<Link> getState();
 
     @OslcName("desiredState")
     @OslcPropertyDefinition(Oslc_autoDomainConstants.AUTOMATION_NAMSPACE + "desiredState")
@@ -200,7 +200,7 @@ public interface IAutomationResult
     @OslcOccurs(Occurs.OneOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getVerdict();
+    public Set<Link> getVerdict();
 
     @OslcName("contribution")
     @OslcPropertyDefinition(Oslc_autoDomainConstants.AUTOMATION_NAMSPACE + "contribution")
@@ -208,7 +208,7 @@ public interface IAutomationResult
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getContribution();
+    public Set<Link> getContribution();
 
     @OslcName("inputParameter")
     @OslcPropertyDefinition(Oslc_autoDomainConstants.AUTOMATION_NAMSPACE + "inputParameter")
@@ -217,7 +217,7 @@ public interface IAutomationResult
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_autoDomainConstants.PARAMETERINSTANCE_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getInputParameter();
+    public Set<Link> getInputParameter();
 
     @OslcName("outputParameter")
     @OslcPropertyDefinition(Oslc_autoDomainConstants.AUTOMATION_NAMSPACE + "outputParameter")
@@ -226,7 +226,7 @@ public interface IAutomationResult
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_autoDomainConstants.PARAMETERINSTANCE_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getOutputParameter();
+    public Set<Link> getOutputParameter();
 
     @OslcName("producedByAutomationRequest")
     @OslcPropertyDefinition(Oslc_autoDomainConstants.AUTOMATION_NAMSPACE + "producedByAutomationRequest")
@@ -249,22 +249,22 @@ public interface IAutomationResult
     public Link getReportsOnAutomationPlan();
 
 
-    public void setContributor(final HashSet<Link> contributor );
+    public void setContributor(final Set<Link> contributor );
     public void setCreated(final Date created );
-    public void setCreator(final HashSet<Link> creator );
+    public void setCreator(final Set<Link> creator );
     public void setIdentifier(final String identifier );
     public void setModified(final Date modified );
-    public void setType(final HashSet<Link> type );
-    public void setSubject(final HashSet<String> subject );
+    public void setType(final Set<Link> type );
+    public void setSubject(final Set<String> subject );
     public void setTitle(final String title );
     public void setInstanceShape(final URI instanceShape );
-    public void setServiceProvider(final HashSet<URI> serviceProvider );
-    public void setState(final HashSet<Link> state );
+    public void setServiceProvider(final Set<URI> serviceProvider );
+    public void setState(final Set<Link> state );
     public void setDesiredState(final Link desiredState );
-    public void setVerdict(final HashSet<Link> verdict );
-    public void setContribution(final HashSet<Link> contribution );
-    public void setInputParameter(final HashSet<Link> inputParameter );
-    public void setOutputParameter(final HashSet<Link> outputParameter );
+    public void setVerdict(final Set<Link> verdict );
+    public void setContribution(final Set<Link> contribution );
+    public void setInputParameter(final Set<Link> inputParameter );
+    public void setOutputParameter(final Set<Link> outputParameter );
     public void setProducedByAutomationRequest(final Link producedByAutomationRequest );
     public void setReportsOnAutomationPlan(final Link reportsOnAutomationPlan );
 }

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/IParameterInstance.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/IParameterInstance.java
@@ -111,7 +111,7 @@ public interface IParameterInstance
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType();
+    public Set<Link> getType();
 
     @OslcName("instanceShape")
     @OslcPropertyDefinition(OslcDomainConstants.OSLC_NAMSPACE + "instanceShape")
@@ -125,14 +125,14 @@ public interface IParameterInstance
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider();
+    public Set<URI> getServiceProvider();
 
 
     public void setName(final String name );
     public void setValue(final String value );
     public void setDescription(final String description );
-    public void setType(final HashSet<Link> type );
+    public void setType(final Set<Link> type );
     public void setInstanceShape(final URI instanceShape );
-    public void setServiceProvider(final HashSet<URI> serviceProvider );
+    public void setServiceProvider(final Set<URI> serviceProvider );
 }
 

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/ParameterInstance.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/ParameterInstance.java
@@ -104,13 +104,13 @@ public class ParameterInstance
     private String description;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private HashSet<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<Link>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
     private URI instanceShape;
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private HashSet<URI> serviceProvider = new HashSet<URI>();
+    private Set<URI> serviceProvider = new HashSet<URI>();
     
     // Start of user code classAttributes
     // End of user code
@@ -169,11 +169,13 @@ public class ParameterInstance
         return result;
     }
     
+    @Deprecated
     public String toHtml()
     {
         return toHtml(false);
     }
     
+    @Deprecated
     public String toHtml(boolean asLocalResource)
     {
         String result = "";
@@ -258,7 +260,7 @@ public class ParameterInstance
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType()
+    public Set<Link> getType()
     {
         // Start of user code getterInit:type
         // End of user code
@@ -286,7 +288,7 @@ public class ParameterInstance
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider()
+    public Set<URI> getServiceProvider()
     {
         // Start of user code getterInit:serviceProvider
         // End of user code
@@ -332,7 +334,7 @@ public class ParameterInstance
     
     // Start of user code setterAnnotation:type
     // End of user code
-    public void setType(final HashSet<Link> type )
+    public void setType(final Set<Link> type )
     {
         // Start of user code setterInit:type
         // End of user code
@@ -360,7 +362,7 @@ public class ParameterInstance
     
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
-    public void setServiceProvider(final HashSet<URI> serviceProvider )
+    public void setServiceProvider(final Set<URI> serviceProvider )
     {
         // Start of user code setterInit:serviceProvider
         // End of user code
@@ -375,6 +377,7 @@ public class ParameterInstance
     }
     
     
+    @Deprecated
     static public String nameToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -394,6 +397,7 @@ public class ParameterInstance
         return s;
     }
     
+    @Deprecated
     static public String valueToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -413,6 +417,7 @@ public class ParameterInstance
         return s;
     }
     
+    @Deprecated
     static public String descriptionToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -432,6 +437,7 @@ public class ParameterInstance
         return s;
     }
     
+    @Deprecated
     static public String typeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -450,6 +456,7 @@ public class ParameterInstance
         return s;
     }
     
+    @Deprecated
     static public String instanceShapeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -469,6 +476,7 @@ public class ParameterInstance
         return s;
     }
     
+    @Deprecated
     static public String serviceProviderToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -489,6 +497,7 @@ public class ParameterInstance
     }
     
     
+    @Deprecated
     public String nameToHtml()
     {
         String s = "";
@@ -513,6 +522,7 @@ public class ParameterInstance
         return s;
     }
     
+    @Deprecated
     public String valueToHtml()
     {
         String s = "";
@@ -537,6 +547,7 @@ public class ParameterInstance
         return s;
     }
     
+    @Deprecated
     public String descriptionToHtml()
     {
         String s = "";
@@ -561,6 +572,7 @@ public class ParameterInstance
         return s;
     }
     
+    @Deprecated
     public String typeToHtml()
     {
         String s = "";
@@ -591,6 +603,7 @@ public class ParameterInstance
         return s;
     }
     
+    @Deprecated
     public String instanceShapeToHtml()
     {
         String s = "";
@@ -615,6 +628,7 @@ public class ParameterInstance
         return s;
     }
     
+    @Deprecated
     public String serviceProviderToHtml()
     {
         String s = "";

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/ChangeRequest.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/ChangeRequest.java
@@ -118,13 +118,13 @@ public class ChangeRequest
     private String identifier;
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private HashSet<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<String>();
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private HashSet<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<Link>();
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private HashSet<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<Link>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
@@ -133,16 +133,16 @@ public class ChangeRequest
     private Date modified;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private HashSet<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<Link>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private HashSet<URI> serviceProvider = new HashSet<URI>();
+    private Set<URI> serviceProvider = new HashSet<URI>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
     private URI instanceShape;
     // Start of user code attributeAnnotation:discussedBy
     // End of user code
-    private Link discussedBy = new Link();
+    private Link discussedBy;
     // Start of user code attributeAnnotation:closeDate
     // End of user code
     private Date closeDate;
@@ -169,25 +169,25 @@ public class ChangeRequest
     private Boolean verified;
     // Start of user code attributeAnnotation:relatedChangeRequest
     // End of user code
-    private HashSet<Link> relatedChangeRequest = new HashSet<Link>();
+    private Set<Link> relatedChangeRequest = new HashSet<Link>();
     // Start of user code attributeAnnotation:affectsPlanItem
     // End of user code
-    private HashSet<Link> affectsPlanItem = new HashSet<Link>();
+    private Set<Link> affectsPlanItem = new HashSet<Link>();
     // Start of user code attributeAnnotation:affectedByDefect
     // End of user code
-    private HashSet<Link> affectedByDefect = new HashSet<Link>();
+    private Set<Link> affectedByDefect = new HashSet<Link>();
     // Start of user code attributeAnnotation:tracksRequirement
     // End of user code
-    private HashSet<Link> tracksRequirement = new HashSet<Link>();
+    private Set<Link> tracksRequirement = new HashSet<Link>();
     // Start of user code attributeAnnotation:implementsRequirement
     // End of user code
-    private HashSet<Link> implementsRequirement = new HashSet<Link>();
+    private Set<Link> implementsRequirement = new HashSet<Link>();
     // Start of user code attributeAnnotation:affectsRequirement
     // End of user code
-    private HashSet<Link> affectsRequirement = new HashSet<Link>();
+    private Set<Link> affectsRequirement = new HashSet<Link>();
     // Start of user code attributeAnnotation:tracksChangeSet
     // End of user code
-    private HashSet<Link> tracksChangeSet = new HashSet<Link>();
+    private Set<Link> tracksChangeSet = new HashSet<Link>();
     
     // Start of user code classAttributes
     // End of user code
@@ -246,11 +246,13 @@ public class ChangeRequest
         return result;
     }
     
+    @Deprecated
     public String toHtml()
     {
         return toHtml(false);
     }
     
+    @Deprecated
     public String toHtml(boolean asLocalResource)
     {
         String result = "";
@@ -402,7 +404,7 @@ public class ChangeRequest
     @OslcValueType(ValueType.String)
     @OslcReadOnly(false)
     @OslcTitle("")
-    public HashSet<String> getSubject()
+    public Set<String> getSubject()
     {
         // Start of user code getterInit:subject
         // End of user code
@@ -418,7 +420,7 @@ public class ChangeRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator()
+    public Set<Link> getCreator()
     {
         // Start of user code getterInit:creator
         // End of user code
@@ -434,7 +436,7 @@ public class ChangeRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor()
+    public Set<Link> getContributor()
     {
         // Start of user code getterInit:contributor
         // End of user code
@@ -479,7 +481,7 @@ public class ChangeRequest
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType()
+    public Set<Link> getType()
     {
         // Start of user code getterInit:type
         // End of user code
@@ -493,7 +495,7 @@ public class ChangeRequest
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider()
+    public Set<URI> getServiceProvider()
     {
         // Start of user code getterInit:serviceProvider
         // End of user code
@@ -659,7 +661,7 @@ public class ChangeRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_cmDomainConstants.CHANGEREQUEST_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getRelatedChangeRequest()
+    public Set<Link> getRelatedChangeRequest()
     {
         // Start of user code getterInit:relatedChangeRequest
         // End of user code
@@ -675,7 +677,7 @@ public class ChangeRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_cmDomainConstants.CHANGEREQUEST_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getAffectsPlanItem()
+    public Set<Link> getAffectsPlanItem()
     {
         // Start of user code getterInit:affectsPlanItem
         // End of user code
@@ -691,7 +693,7 @@ public class ChangeRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_cmDomainConstants.CHANGEREQUEST_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getAffectedByDefect()
+    public Set<Link> getAffectedByDefect()
     {
         // Start of user code getterInit:affectedByDefect
         // End of user code
@@ -707,7 +709,7 @@ public class ChangeRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_rmDomainConstants.REQUIREMENT_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getTracksRequirement()
+    public Set<Link> getTracksRequirement()
     {
         // Start of user code getterInit:tracksRequirement
         // End of user code
@@ -723,7 +725,7 @@ public class ChangeRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_rmDomainConstants.REQUIREMENT_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getImplementsRequirement()
+    public Set<Link> getImplementsRequirement()
     {
         // Start of user code getterInit:implementsRequirement
         // End of user code
@@ -739,7 +741,7 @@ public class ChangeRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_rmDomainConstants.REQUIREMENT_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getAffectsRequirement()
+    public Set<Link> getAffectsRequirement()
     {
         // Start of user code getterInit:affectsRequirement
         // End of user code
@@ -754,7 +756,7 @@ public class ChangeRequest
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getTracksChangeSet()
+    public Set<Link> getTracksChangeSet()
     {
         // Start of user code getterInit:tracksChangeSet
         // End of user code
@@ -812,7 +814,7 @@ public class ChangeRequest
     
     // Start of user code setterAnnotation:subject
     // End of user code
-    public void setSubject(final HashSet<String> subject )
+    public void setSubject(final Set<String> subject )
     {
         // Start of user code setterInit:subject
         // End of user code
@@ -828,7 +830,7 @@ public class ChangeRequest
     
     // Start of user code setterAnnotation:creator
     // End of user code
-    public void setCreator(final HashSet<Link> creator )
+    public void setCreator(final Set<Link> creator )
     {
         // Start of user code setterInit:creator
         // End of user code
@@ -844,7 +846,7 @@ public class ChangeRequest
     
     // Start of user code setterAnnotation:contributor
     // End of user code
-    public void setContributor(final HashSet<Link> contributor )
+    public void setContributor(final Set<Link> contributor )
     {
         // Start of user code setterInit:contributor
         // End of user code
@@ -884,7 +886,7 @@ public class ChangeRequest
     
     // Start of user code setterAnnotation:type
     // End of user code
-    public void setType(final HashSet<Link> type )
+    public void setType(final Set<Link> type )
     {
         // Start of user code setterInit:type
         // End of user code
@@ -900,7 +902,7 @@ public class ChangeRequest
     
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
-    public void setServiceProvider(final HashSet<URI> serviceProvider )
+    public void setServiceProvider(final Set<URI> serviceProvider )
     {
         // Start of user code setterInit:serviceProvider
         // End of user code
@@ -1036,7 +1038,7 @@ public class ChangeRequest
     
     // Start of user code setterAnnotation:relatedChangeRequest
     // End of user code
-    public void setRelatedChangeRequest(final HashSet<Link> relatedChangeRequest )
+    public void setRelatedChangeRequest(final Set<Link> relatedChangeRequest )
     {
         // Start of user code setterInit:relatedChangeRequest
         // End of user code
@@ -1052,7 +1054,7 @@ public class ChangeRequest
     
     // Start of user code setterAnnotation:affectsPlanItem
     // End of user code
-    public void setAffectsPlanItem(final HashSet<Link> affectsPlanItem )
+    public void setAffectsPlanItem(final Set<Link> affectsPlanItem )
     {
         // Start of user code setterInit:affectsPlanItem
         // End of user code
@@ -1068,7 +1070,7 @@ public class ChangeRequest
     
     // Start of user code setterAnnotation:affectedByDefect
     // End of user code
-    public void setAffectedByDefect(final HashSet<Link> affectedByDefect )
+    public void setAffectedByDefect(final Set<Link> affectedByDefect )
     {
         // Start of user code setterInit:affectedByDefect
         // End of user code
@@ -1084,7 +1086,7 @@ public class ChangeRequest
     
     // Start of user code setterAnnotation:tracksRequirement
     // End of user code
-    public void setTracksRequirement(final HashSet<Link> tracksRequirement )
+    public void setTracksRequirement(final Set<Link> tracksRequirement )
     {
         // Start of user code setterInit:tracksRequirement
         // End of user code
@@ -1100,7 +1102,7 @@ public class ChangeRequest
     
     // Start of user code setterAnnotation:implementsRequirement
     // End of user code
-    public void setImplementsRequirement(final HashSet<Link> implementsRequirement )
+    public void setImplementsRequirement(final Set<Link> implementsRequirement )
     {
         // Start of user code setterInit:implementsRequirement
         // End of user code
@@ -1116,7 +1118,7 @@ public class ChangeRequest
     
     // Start of user code setterAnnotation:affectsRequirement
     // End of user code
-    public void setAffectsRequirement(final HashSet<Link> affectsRequirement )
+    public void setAffectsRequirement(final Set<Link> affectsRequirement )
     {
         // Start of user code setterInit:affectsRequirement
         // End of user code
@@ -1132,7 +1134,7 @@ public class ChangeRequest
     
     // Start of user code setterAnnotation:tracksChangeSet
     // End of user code
-    public void setTracksChangeSet(final HashSet<Link> tracksChangeSet )
+    public void setTracksChangeSet(final Set<Link> tracksChangeSet )
     {
         // Start of user code setterInit:tracksChangeSet
         // End of user code
@@ -1147,6 +1149,7 @@ public class ChangeRequest
     }
     
     
+    @Deprecated
     static public String shortTitleToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1166,6 +1169,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String descriptionToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1185,6 +1189,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String titleToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1204,6 +1209,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String identifierToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1223,6 +1229,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String subjectToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1242,6 +1249,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String creatorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1260,6 +1268,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String contributorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1278,6 +1287,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String createdToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1297,6 +1307,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String modifiedToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1316,6 +1327,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String typeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1334,6 +1346,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String serviceProviderToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1353,6 +1366,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String instanceShapeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1372,6 +1386,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String discussedByToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1390,6 +1405,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String closeDateToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1409,6 +1425,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String statusToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1428,6 +1445,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String closedToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1447,6 +1465,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String inprogressToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1466,6 +1485,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String fixedToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1485,6 +1505,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String approvedToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1504,6 +1525,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String reviewedToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1523,6 +1545,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String verifiedToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1542,6 +1565,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String relatedChangeRequestToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1560,6 +1584,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String affectsPlanItemToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1578,6 +1603,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String affectedByDefectToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1596,6 +1622,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String tracksRequirementToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1614,6 +1641,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String implementsRequirementToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1632,6 +1660,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String affectsRequirementToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1650,6 +1679,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     static public String tracksChangeSetToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1669,6 +1699,7 @@ public class ChangeRequest
     }
     
     
+    @Deprecated
     public String shortTitleToHtml()
     {
         String s = "";
@@ -1693,6 +1724,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String descriptionToHtml()
     {
         String s = "";
@@ -1717,6 +1749,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String titleToHtml()
     {
         String s = "";
@@ -1741,6 +1774,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String identifierToHtml()
     {
         String s = "";
@@ -1765,6 +1799,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String subjectToHtml()
     {
         String s = "";
@@ -1791,6 +1826,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String creatorToHtml()
     {
         String s = "";
@@ -1816,6 +1852,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String contributorToHtml()
     {
         String s = "";
@@ -1841,6 +1878,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String createdToHtml()
     {
         String s = "";
@@ -1865,6 +1903,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String modifiedToHtml()
     {
         String s = "";
@@ -1889,6 +1928,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String typeToHtml()
     {
         String s = "";
@@ -1919,6 +1959,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String serviceProviderToHtml()
     {
         String s = "";
@@ -1945,6 +1986,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String instanceShapeToHtml()
     {
         String s = "";
@@ -1969,6 +2011,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String discussedByToHtml()
     {
         String s = "";
@@ -1993,6 +2036,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String closeDateToHtml()
     {
         String s = "";
@@ -2017,6 +2061,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String statusToHtml()
     {
         String s = "";
@@ -2041,6 +2086,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String closedToHtml()
     {
         String s = "";
@@ -2065,6 +2111,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String inprogressToHtml()
     {
         String s = "";
@@ -2089,6 +2136,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String fixedToHtml()
     {
         String s = "";
@@ -2113,6 +2161,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String approvedToHtml()
     {
         String s = "";
@@ -2137,6 +2186,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String reviewedToHtml()
     {
         String s = "";
@@ -2161,6 +2211,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String verifiedToHtml()
     {
         String s = "";
@@ -2185,6 +2236,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String relatedChangeRequestToHtml()
     {
         String s = "";
@@ -2210,6 +2262,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String affectsPlanItemToHtml()
     {
         String s = "";
@@ -2235,6 +2288,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String affectedByDefectToHtml()
     {
         String s = "";
@@ -2260,6 +2314,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String tracksRequirementToHtml()
     {
         String s = "";
@@ -2285,6 +2340,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String implementsRequirementToHtml()
     {
         String s = "";
@@ -2310,6 +2366,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String affectsRequirementToHtml()
     {
         String s = "";
@@ -2335,6 +2392,7 @@ public class ChangeRequest
         return s;
     }
     
+    @Deprecated
     public String tracksChangeSetToHtml()
     {
         String s = "";

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/IChangeRequest.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/IChangeRequest.java
@@ -142,7 +142,7 @@ public interface IChangeRequest
     @OslcValueType(ValueType.String)
     @OslcReadOnly(false)
     @OslcTitle("")
-    public HashSet<String> getSubject();
+    public Set<String> getSubject();
 
     @OslcName("creator")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "creator")
@@ -151,7 +151,7 @@ public interface IChangeRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator();
+    public Set<Link> getCreator();
 
     @OslcName("contributor")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "contributor")
@@ -160,7 +160,7 @@ public interface IChangeRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor();
+    public Set<Link> getContributor();
 
     @OslcName("created")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "created")
@@ -184,14 +184,14 @@ public interface IChangeRequest
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType();
+    public Set<Link> getType();
 
     @OslcName("serviceProvider")
     @OslcPropertyDefinition(OslcDomainConstants.OSLC_NAMSPACE + "serviceProvider")
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider();
+    public Set<URI> getServiceProvider();
 
     @OslcName("instanceShape")
     @OslcPropertyDefinition(OslcDomainConstants.OSLC_NAMSPACE + "instanceShape")
@@ -280,7 +280,7 @@ public interface IChangeRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_cmDomainConstants.CHANGEREQUEST_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getRelatedChangeRequest();
+    public Set<Link> getRelatedChangeRequest();
 
     @OslcName("affectsPlanItem")
     @OslcPropertyDefinition(Oslc_cmDomainConstants.CHANGE_MANAGEMENT_NAMSPACE + "affectsPlanItem")
@@ -289,7 +289,7 @@ public interface IChangeRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_cmDomainConstants.CHANGEREQUEST_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getAffectsPlanItem();
+    public Set<Link> getAffectsPlanItem();
 
     @OslcName("affectedByDefect")
     @OslcPropertyDefinition(Oslc_cmDomainConstants.CHANGE_MANAGEMENT_NAMSPACE + "affectedByDefect")
@@ -298,7 +298,7 @@ public interface IChangeRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_cmDomainConstants.CHANGEREQUEST_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getAffectedByDefect();
+    public Set<Link> getAffectedByDefect();
 
     @OslcName("tracksRequirement")
     @OslcPropertyDefinition(Oslc_cmDomainConstants.CHANGE_MANAGEMENT_NAMSPACE + "tracksRequirement")
@@ -307,7 +307,7 @@ public interface IChangeRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_rmDomainConstants.REQUIREMENT_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getTracksRequirement();
+    public Set<Link> getTracksRequirement();
 
     @OslcName("implementsRequirement")
     @OslcPropertyDefinition(Oslc_cmDomainConstants.CHANGE_MANAGEMENT_NAMSPACE + "implementsRequirement")
@@ -316,7 +316,7 @@ public interface IChangeRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_rmDomainConstants.REQUIREMENT_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getImplementsRequirement();
+    public Set<Link> getImplementsRequirement();
 
     @OslcName("affectsRequirement")
     @OslcPropertyDefinition(Oslc_cmDomainConstants.CHANGE_MANAGEMENT_NAMSPACE + "affectsRequirement")
@@ -325,7 +325,7 @@ public interface IChangeRequest
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_rmDomainConstants.REQUIREMENT_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getAffectsRequirement();
+    public Set<Link> getAffectsRequirement();
 
     @OslcName("tracksChangeSet")
     @OslcPropertyDefinition(Oslc_cmDomainConstants.CHANGE_MANAGEMENT_NAMSPACE + "tracksChangeSet")
@@ -333,20 +333,20 @@ public interface IChangeRequest
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getTracksChangeSet();
+    public Set<Link> getTracksChangeSet();
 
 
     public void setShortTitle(final String shortTitle );
     public void setDescription(final String description );
     public void setTitle(final String title );
     public void setIdentifier(final String identifier );
-    public void setSubject(final HashSet<String> subject );
-    public void setCreator(final HashSet<Link> creator );
-    public void setContributor(final HashSet<Link> contributor );
+    public void setSubject(final Set<String> subject );
+    public void setCreator(final Set<Link> creator );
+    public void setContributor(final Set<Link> contributor );
     public void setCreated(final Date created );
     public void setModified(final Date modified );
-    public void setType(final HashSet<Link> type );
-    public void setServiceProvider(final HashSet<URI> serviceProvider );
+    public void setType(final Set<Link> type );
+    public void setServiceProvider(final Set<URI> serviceProvider );
     public void setInstanceShape(final URI instanceShape );
     public void setDiscussedBy(final Link discussedBy );
     public void setCloseDate(final Date closeDate );
@@ -357,12 +357,12 @@ public interface IChangeRequest
     public void setApproved(final Boolean approved );
     public void setReviewed(final Boolean reviewed );
     public void setVerified(final Boolean verified );
-    public void setRelatedChangeRequest(final HashSet<Link> relatedChangeRequest );
-    public void setAffectsPlanItem(final HashSet<Link> affectsPlanItem );
-    public void setAffectedByDefect(final HashSet<Link> affectedByDefect );
-    public void setTracksRequirement(final HashSet<Link> tracksRequirement );
-    public void setImplementsRequirement(final HashSet<Link> implementsRequirement );
-    public void setAffectsRequirement(final HashSet<Link> affectsRequirement );
-    public void setTracksChangeSet(final HashSet<Link> tracksChangeSet );
+    public void setRelatedChangeRequest(final Set<Link> relatedChangeRequest );
+    public void setAffectsPlanItem(final Set<Link> affectsPlanItem );
+    public void setAffectedByDefect(final Set<Link> affectedByDefect );
+    public void setTracksRequirement(final Set<Link> tracksRequirement );
+    public void setImplementsRequirement(final Set<Link> implementsRequirement );
+    public void setAffectsRequirement(final Set<Link> affectsRequirement );
+    public void setTracksChangeSet(final Set<Link> tracksChangeSet );
 }
 

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/IVersionResource.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/IVersionResource.java
@@ -100,7 +100,7 @@ public interface IVersionResource
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor();
+    public Set<Link> getContributor();
 
     @OslcName("created")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "created")
@@ -117,7 +117,7 @@ public interface IVersionResource
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator();
+    public Set<Link> getCreator();
 
     @OslcName("description")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "description")
@@ -159,7 +159,7 @@ public interface IVersionResource
     @OslcValueType(ValueType.String)
     @OslcReadOnly(false)
     @OslcTitle("")
-    public HashSet<String> getSubject();
+    public Set<String> getSubject();
 
     @OslcName("title")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "title")
@@ -183,7 +183,7 @@ public interface IVersionResource
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(true)
-    public HashSet<Link> getCommitter();
+    public Set<Link> getCommitter();
 
     @OslcName("component")
     @OslcPropertyDefinition(Oslc_configDomainConstants.CONFIGURATION_MANAGEMENT_NAMSPACE + "component")
@@ -191,7 +191,7 @@ public interface IVersionResource
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.String)
     @OslcReadOnly(false)
-    public HashSet<String> getComponent();
+    public Set<String> getComponent();
 
     @OslcName("versionId")
     @OslcPropertyDefinition(Oslc_configDomainConstants.CONFIGURATION_MANAGEMENT_NAMSPACE + "versionId")
@@ -221,7 +221,7 @@ public interface IVersionResource
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider();
+    public Set<URI> getServiceProvider();
 
     @OslcName("shortId")
     @OslcPropertyDefinition(OslcDomainConstants.OSLC_NAMSPACE + "shortId")
@@ -245,7 +245,7 @@ public interface IVersionResource
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType();
+    public Set<Link> getType();
 
     @OslcName("wasDerivedFrom")
     @OslcPropertyDefinition(ProvDomainConstants.PROVENANCE_NAMSPACE + "wasDerivedFrom")
@@ -254,7 +254,7 @@ public interface IVersionResource
     @OslcValueType(ValueType.Resource)
     @OslcRepresentation(Representation.Reference)
     @OslcReadOnly(false)
-    public HashSet<Link> getWasDerivedFrom();
+    public Set<Link> getWasDerivedFrom();
 
     @OslcName("wasRevisionOf")
     @OslcPropertyDefinition(ProvDomainConstants.PROVENANCE_NAMSPACE + "wasRevisionOf")
@@ -263,29 +263,29 @@ public interface IVersionResource
     @OslcValueType(ValueType.Resource)
     @OslcRepresentation(Representation.Reference)
     @OslcReadOnly(false)
-    public HashSet<Link> getWasRevisionOf();
+    public Set<Link> getWasRevisionOf();
 
 
-    public void setContributor(final HashSet<Link> contributor );
+    public void setContributor(final Set<Link> contributor );
     public void setCreated(final Date created );
-    public void setCreator(final HashSet<Link> creator );
+    public void setCreator(final Set<Link> creator );
     public void setDescription(final String description );
     public void setIdentifier(final String identifier );
     public void setIsVersionOf(final Link isVersionOf );
     public void setModified(final Date modified );
-    public void setSubject(final HashSet<String> subject );
+    public void setSubject(final Set<String> subject );
     public void setTitle(final String title );
     public void setCommitted(final Date committed );
-    public void setCommitter(final HashSet<Link> committer );
-    public void setComponent(final HashSet<String> component );
+    public void setCommitter(final Set<Link> committer );
+    public void setComponent(final Set<String> component );
     public void setVersionId(final String versionId );
     public void setInstanceShape(final URI instanceShape );
     public void setModifiedBy(final Link modifiedBy );
-    public void setServiceProvider(final HashSet<URI> serviceProvider );
+    public void setServiceProvider(final Set<URI> serviceProvider );
     public void setShortId(final String shortId );
     public void setShortTitle(final String shortTitle );
-    public void setType(final HashSet<Link> type );
-    public void setWasDerivedFrom(final HashSet<Link> wasDerivedFrom );
-    public void setWasRevisionOf(final HashSet<Link> wasRevisionOf );
+    public void setType(final Set<Link> type );
+    public void setWasDerivedFrom(final Set<Link> wasDerivedFrom );
+    public void setWasRevisionOf(final Set<Link> wasRevisionOf );
 }
 

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/VersionResource.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/VersionResource.java
@@ -99,13 +99,13 @@ public class VersionResource
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private HashSet<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<Link>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private HashSet<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<Link>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -114,13 +114,13 @@ public class VersionResource
     private String identifier;
     // Start of user code attributeAnnotation:isVersionOf
     // End of user code
-    private Link isVersionOf = new Link();
+    private Link isVersionOf;
     // Start of user code attributeAnnotation:modified
     // End of user code
     private Date modified;
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private HashSet<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<String>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
@@ -129,10 +129,10 @@ public class VersionResource
     private Date committed;
     // Start of user code attributeAnnotation:committer
     // End of user code
-    private HashSet<Link> committer = new HashSet<Link>();
+    private Set<Link> committer = new HashSet<Link>();
     // Start of user code attributeAnnotation:component
     // End of user code
-    private HashSet<String> component = new HashSet<String>();
+    private Set<String> component = new HashSet<String>();
     // Start of user code attributeAnnotation:versionId
     // End of user code
     private String versionId;
@@ -141,10 +141,10 @@ public class VersionResource
     private URI instanceShape;
     // Start of user code attributeAnnotation:modifiedBy
     // End of user code
-    private Link modifiedBy = new Link();
+    private Link modifiedBy;
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private HashSet<URI> serviceProvider = new HashSet<URI>();
+    private Set<URI> serviceProvider = new HashSet<URI>();
     // Start of user code attributeAnnotation:shortId
     // End of user code
     private String shortId;
@@ -153,13 +153,13 @@ public class VersionResource
     private String shortTitle;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private HashSet<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<Link>();
     // Start of user code attributeAnnotation:wasDerivedFrom
     // End of user code
-    private HashSet<Link> wasDerivedFrom = new HashSet<Link>();
+    private Set<Link> wasDerivedFrom = new HashSet<Link>();
     // Start of user code attributeAnnotation:wasRevisionOf
     // End of user code
-    private HashSet<Link> wasRevisionOf = new HashSet<Link>();
+    private Set<Link> wasRevisionOf = new HashSet<Link>();
     
     // Start of user code classAttributes
     // End of user code
@@ -218,11 +218,13 @@ public class VersionResource
         return result;
     }
     
+    @Deprecated
     public String toHtml()
     {
         return toHtml(false);
     }
     
+    @Deprecated
     public String toHtml(boolean asLocalResource)
     {
         String result = "";
@@ -299,7 +301,7 @@ public class VersionResource
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor()
+    public Set<Link> getContributor()
     {
         // Start of user code getterInit:contributor
         // End of user code
@@ -330,7 +332,7 @@ public class VersionResource
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator()
+    public Set<Link> getCreator()
     {
         // Start of user code getterInit:creator
         // End of user code
@@ -407,7 +409,7 @@ public class VersionResource
     @OslcValueType(ValueType.String)
     @OslcReadOnly(false)
     @OslcTitle("")
-    public HashSet<String> getSubject()
+    public Set<String> getSubject()
     {
         // Start of user code getterInit:subject
         // End of user code
@@ -452,7 +454,7 @@ public class VersionResource
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(true)
-    public HashSet<Link> getCommitter()
+    public Set<Link> getCommitter()
     {
         // Start of user code getterInit:committer
         // End of user code
@@ -467,7 +469,7 @@ public class VersionResource
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.String)
     @OslcReadOnly(false)
-    public HashSet<String> getComponent()
+    public Set<String> getComponent()
     {
         // Start of user code getterInit:component
         // End of user code
@@ -525,7 +527,7 @@ public class VersionResource
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider()
+    public Set<URI> getServiceProvider()
     {
         // Start of user code getterInit:serviceProvider
         // End of user code
@@ -570,7 +572,7 @@ public class VersionResource
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType()
+    public Set<Link> getType()
     {
         // Start of user code getterInit:type
         // End of user code
@@ -586,7 +588,7 @@ public class VersionResource
     @OslcValueType(ValueType.Resource)
     @OslcRepresentation(Representation.Reference)
     @OslcReadOnly(false)
-    public HashSet<Link> getWasDerivedFrom()
+    public Set<Link> getWasDerivedFrom()
     {
         // Start of user code getterInit:wasDerivedFrom
         // End of user code
@@ -602,7 +604,7 @@ public class VersionResource
     @OslcValueType(ValueType.Resource)
     @OslcRepresentation(Representation.Reference)
     @OslcReadOnly(false)
-    public HashSet<Link> getWasRevisionOf()
+    public Set<Link> getWasRevisionOf()
     {
         // Start of user code getterInit:wasRevisionOf
         // End of user code
@@ -612,7 +614,7 @@ public class VersionResource
     
     // Start of user code setterAnnotation:contributor
     // End of user code
-    public void setContributor(final HashSet<Link> contributor )
+    public void setContributor(final Set<Link> contributor )
     {
         // Start of user code setterInit:contributor
         // End of user code
@@ -640,7 +642,7 @@ public class VersionResource
     
     // Start of user code setterAnnotation:creator
     // End of user code
-    public void setCreator(final HashSet<Link> creator )
+    public void setCreator(final Set<Link> creator )
     {
         // Start of user code setterInit:creator
         // End of user code
@@ -704,7 +706,7 @@ public class VersionResource
     
     // Start of user code setterAnnotation:subject
     // End of user code
-    public void setSubject(final HashSet<String> subject )
+    public void setSubject(final Set<String> subject )
     {
         // Start of user code setterInit:subject
         // End of user code
@@ -744,7 +746,7 @@ public class VersionResource
     
     // Start of user code setterAnnotation:committer
     // End of user code
-    public void setCommitter(final HashSet<Link> committer )
+    public void setCommitter(final Set<Link> committer )
     {
         // Start of user code setterInit:committer
         // End of user code
@@ -760,7 +762,7 @@ public class VersionResource
     
     // Start of user code setterAnnotation:component
     // End of user code
-    public void setComponent(final HashSet<String> component )
+    public void setComponent(final Set<String> component )
     {
         // Start of user code setterInit:component
         // End of user code
@@ -812,7 +814,7 @@ public class VersionResource
     
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
-    public void setServiceProvider(final HashSet<URI> serviceProvider )
+    public void setServiceProvider(final Set<URI> serviceProvider )
     {
         // Start of user code setterInit:serviceProvider
         // End of user code
@@ -852,7 +854,7 @@ public class VersionResource
     
     // Start of user code setterAnnotation:type
     // End of user code
-    public void setType(final HashSet<Link> type )
+    public void setType(final Set<Link> type )
     {
         // Start of user code setterInit:type
         // End of user code
@@ -868,7 +870,7 @@ public class VersionResource
     
     // Start of user code setterAnnotation:wasDerivedFrom
     // End of user code
-    public void setWasDerivedFrom(final HashSet<Link> wasDerivedFrom )
+    public void setWasDerivedFrom(final Set<Link> wasDerivedFrom )
     {
         // Start of user code setterInit:wasDerivedFrom
         // End of user code
@@ -884,7 +886,7 @@ public class VersionResource
     
     // Start of user code setterAnnotation:wasRevisionOf
     // End of user code
-    public void setWasRevisionOf(final HashSet<Link> wasRevisionOf )
+    public void setWasRevisionOf(final Set<Link> wasRevisionOf )
     {
         // Start of user code setterInit:wasRevisionOf
         // End of user code
@@ -899,6 +901,7 @@ public class VersionResource
     }
     
     
+    @Deprecated
     static public String contributorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -917,6 +920,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     static public String createdToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -936,6 +940,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     static public String creatorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -954,6 +959,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     static public String descriptionToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -973,6 +979,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     static public String identifierToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -992,6 +999,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     static public String isVersionOfToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1010,6 +1018,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     static public String modifiedToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1029,6 +1038,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     static public String subjectToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1048,6 +1058,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     static public String titleToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1067,6 +1078,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     static public String committedToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1086,6 +1098,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     static public String committerToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1104,6 +1117,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     static public String componentToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1123,6 +1137,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     static public String versionIdToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1142,6 +1157,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     static public String instanceShapeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1161,6 +1177,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     static public String modifiedByToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1179,6 +1196,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     static public String serviceProviderToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1198,6 +1216,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     static public String shortIdToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1217,6 +1236,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     static public String shortTitleToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1236,6 +1256,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     static public String typeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1254,6 +1275,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     static public String wasDerivedFromToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1272,6 +1294,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     static public String wasRevisionOfToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1291,6 +1314,7 @@ public class VersionResource
     }
     
     
+    @Deprecated
     public String contributorToHtml()
     {
         String s = "";
@@ -1316,6 +1340,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     public String createdToHtml()
     {
         String s = "";
@@ -1340,6 +1365,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     public String creatorToHtml()
     {
         String s = "";
@@ -1365,6 +1391,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     public String descriptionToHtml()
     {
         String s = "";
@@ -1389,6 +1416,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     public String identifierToHtml()
     {
         String s = "";
@@ -1413,6 +1441,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     public String isVersionOfToHtml()
     {
         String s = "";
@@ -1437,6 +1466,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     public String modifiedToHtml()
     {
         String s = "";
@@ -1461,6 +1491,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     public String subjectToHtml()
     {
         String s = "";
@@ -1487,6 +1518,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     public String titleToHtml()
     {
         String s = "";
@@ -1511,6 +1543,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     public String committedToHtml()
     {
         String s = "";
@@ -1535,6 +1568,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     public String committerToHtml()
     {
         String s = "";
@@ -1565,6 +1599,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     public String componentToHtml()
     {
         String s = "";
@@ -1591,6 +1626,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     public String versionIdToHtml()
     {
         String s = "";
@@ -1615,6 +1651,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     public String instanceShapeToHtml()
     {
         String s = "";
@@ -1639,6 +1676,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     public String modifiedByToHtml()
     {
         String s = "";
@@ -1663,6 +1701,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     public String serviceProviderToHtml()
     {
         String s = "";
@@ -1689,6 +1728,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     public String shortIdToHtml()
     {
         String s = "";
@@ -1713,6 +1753,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     public String shortTitleToHtml()
     {
         String s = "";
@@ -1737,6 +1778,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     public String typeToHtml()
     {
         String s = "";
@@ -1767,6 +1809,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     public String wasDerivedFromToHtml()
     {
         String s = "";
@@ -1797,6 +1840,7 @@ public class VersionResource
         return s;
     }
     
+    @Deprecated
     public String wasRevisionOfToHtml()
     {
         String s = "";

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/ITestCase.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/ITestCase.java
@@ -105,7 +105,7 @@ public interface ITestCase
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor();
+    public Set<Link> getContributor();
 
     @OslcName("created")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "created")
@@ -122,7 +122,7 @@ public interface ITestCase
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator();
+    public Set<Link> getCreator();
 
     @OslcName("description")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "description")
@@ -160,7 +160,7 @@ public interface ITestCase
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider();
+    public Set<URI> getServiceProvider();
 
     @OslcName("subject")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "subject")
@@ -169,7 +169,7 @@ public interface ITestCase
     @OslcValueType(ValueType.String)
     @OslcReadOnly(false)
     @OslcTitle("")
-    public HashSet<String> getSubject();
+    public Set<String> getSubject();
 
     @OslcName("title")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "title")
@@ -185,7 +185,7 @@ public interface ITestCase
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType();
+    public Set<Link> getType();
 
     @OslcName("relatedChangeRequest")
     @OslcPropertyDefinition(Oslc_qmDomainConstants.QUALITY_MANAGEMENT_NAMSPACE + "relatedChangeRequest")
@@ -195,7 +195,7 @@ public interface ITestCase
     @OslcRepresentation(Representation.Reference)
     @OslcRange({Oslc_cmDomainConstants.CHANGEREQUEST_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getRelatedChangeRequest();
+    public Set<Link> getRelatedChangeRequest();
 
     @OslcName("testsChangeRequest")
     @OslcPropertyDefinition(Oslc_qmDomainConstants.QUALITY_MANAGEMENT_NAMSPACE + "testsChangeRequest")
@@ -205,7 +205,7 @@ public interface ITestCase
     @OslcRepresentation(Representation.Reference)
     @OslcRange({Oslc_cmDomainConstants.CHANGEREQUEST_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getTestsChangeRequest();
+    public Set<Link> getTestsChangeRequest();
 
     @OslcName("usesTestScript")
     @OslcPropertyDefinition(Oslc_qmDomainConstants.QUALITY_MANAGEMENT_NAMSPACE + "usesTestScript")
@@ -214,7 +214,7 @@ public interface ITestCase
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_qmDomainConstants.TESTSCRIPT_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getUsesTestScript();
+    public Set<Link> getUsesTestScript();
 
     @OslcName("validatesRequirement")
     @OslcPropertyDefinition(Oslc_qmDomainConstants.QUALITY_MANAGEMENT_NAMSPACE + "validatesRequirement")
@@ -224,23 +224,23 @@ public interface ITestCase
     @OslcRepresentation(Representation.Reference)
     @OslcRange({Oslc_rmDomainConstants.REQUIREMENT_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getValidatesRequirement();
+    public Set<Link> getValidatesRequirement();
 
 
-    public void setContributor(final HashSet<Link> contributor );
+    public void setContributor(final Set<Link> contributor );
     public void setCreated(final Date created );
-    public void setCreator(final HashSet<Link> creator );
+    public void setCreator(final Set<Link> creator );
     public void setDescription(final String description );
     public void setIdentifier(final String identifier );
     public void setModified(final Date modified );
     public void setInstanceShape(final URI instanceShape );
-    public void setServiceProvider(final HashSet<URI> serviceProvider );
-    public void setSubject(final HashSet<String> subject );
+    public void setServiceProvider(final Set<URI> serviceProvider );
+    public void setSubject(final Set<String> subject );
     public void setTitle(final String title );
-    public void setType(final HashSet<Link> type );
-    public void setRelatedChangeRequest(final HashSet<Link> relatedChangeRequest );
-    public void setTestsChangeRequest(final HashSet<Link> testsChangeRequest );
-    public void setUsesTestScript(final HashSet<Link> usesTestScript );
-    public void setValidatesRequirement(final HashSet<Link> validatesRequirement );
+    public void setType(final Set<Link> type );
+    public void setRelatedChangeRequest(final Set<Link> relatedChangeRequest );
+    public void setTestsChangeRequest(final Set<Link> testsChangeRequest );
+    public void setUsesTestScript(final Set<Link> usesTestScript );
+    public void setValidatesRequirement(final Set<Link> validatesRequirement );
 }
 

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/ITestExecutionRecord.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/ITestExecutionRecord.java
@@ -101,7 +101,7 @@ public interface ITestExecutionRecord
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor();
+    public Set<Link> getContributor();
 
     @OslcName("created")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "created")
@@ -118,7 +118,7 @@ public interface ITestExecutionRecord
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator();
+    public Set<Link> getCreator();
 
     @OslcName("identifier")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "identifier")
@@ -142,7 +142,7 @@ public interface ITestExecutionRecord
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType();
+    public Set<Link> getType();
 
     @OslcName("instanceShape")
     @OslcPropertyDefinition(OslcDomainConstants.OSLC_NAMSPACE + "instanceShape")
@@ -156,7 +156,7 @@ public interface ITestExecutionRecord
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider();
+    public Set<URI> getServiceProvider();
 
     @OslcName("title")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "title")
@@ -174,7 +174,7 @@ public interface ITestExecutionRecord
     @OslcRepresentation(Representation.Reference)
     @OslcRange({Oslc_cmDomainConstants.CHANGEREQUEST_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getBlockedByChangeRequest();
+    public Set<Link> getBlockedByChangeRequest();
 
     @OslcName("relatedChangeRequest")
     @OslcPropertyDefinition(Oslc_qmDomainConstants.QUALITY_MANAGEMENT_NAMSPACE + "relatedChangeRequest")
@@ -184,7 +184,7 @@ public interface ITestExecutionRecord
     @OslcRepresentation(Representation.Reference)
     @OslcRange({Oslc_cmDomainConstants.CHANGEREQUEST_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getRelatedChangeRequest();
+    public Set<Link> getRelatedChangeRequest();
 
     @OslcName("reportsOnTestPlan")
     @OslcPropertyDefinition(Oslc_qmDomainConstants.QUALITY_MANAGEMENT_NAMSPACE + "reportsOnTestPlan")
@@ -214,17 +214,17 @@ public interface ITestExecutionRecord
     public Link getRunsTestCase();
 
 
-    public void setContributor(final HashSet<Link> contributor );
+    public void setContributor(final Set<Link> contributor );
     public void setCreated(final Date created );
-    public void setCreator(final HashSet<Link> creator );
+    public void setCreator(final Set<Link> creator );
     public void setIdentifier(final String identifier );
     public void setModified(final Date modified );
-    public void setType(final HashSet<Link> type );
+    public void setType(final Set<Link> type );
     public void setInstanceShape(final URI instanceShape );
-    public void setServiceProvider(final HashSet<URI> serviceProvider );
+    public void setServiceProvider(final Set<URI> serviceProvider );
     public void setTitle(final String title );
-    public void setBlockedByChangeRequest(final HashSet<Link> blockedByChangeRequest );
-    public void setRelatedChangeRequest(final HashSet<Link> relatedChangeRequest );
+    public void setBlockedByChangeRequest(final Set<Link> blockedByChangeRequest );
+    public void setRelatedChangeRequest(final Set<Link> relatedChangeRequest );
     public void setReportsOnTestPlan(final Link reportsOnTestPlan );
     public void setRunsOnTestEnvironment(final Link runsOnTestEnvironment );
     public void setRunsTestCase(final Link runsTestCase );

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/ITestPlan.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/ITestPlan.java
@@ -103,7 +103,7 @@ public interface ITestPlan
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor();
+    public Set<Link> getContributor();
 
     @OslcName("created")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "created")
@@ -120,7 +120,7 @@ public interface ITestPlan
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator();
+    public Set<Link> getCreator();
 
     @OslcName("description")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "description")
@@ -153,7 +153,7 @@ public interface ITestPlan
     @OslcValueType(ValueType.String)
     @OslcReadOnly(false)
     @OslcTitle("")
-    public HashSet<String> getSubject();
+    public Set<String> getSubject();
 
     @OslcName("title")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "title")
@@ -169,7 +169,7 @@ public interface ITestPlan
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType();
+    public Set<Link> getType();
 
     @OslcName("instanceShape")
     @OslcPropertyDefinition(OslcDomainConstants.OSLC_NAMSPACE + "instanceShape")
@@ -183,7 +183,7 @@ public interface ITestPlan
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider();
+    public Set<URI> getServiceProvider();
 
     @OslcName("usesTestCase")
     @OslcPropertyDefinition(Oslc_qmDomainConstants.QUALITY_MANAGEMENT_NAMSPACE + "usesTestCase")
@@ -192,7 +192,7 @@ public interface ITestPlan
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_qmDomainConstants.TESTCASE_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getUsesTestCase();
+    public Set<Link> getUsesTestCase();
 
     @OslcName("validatesRequirementCollection")
     @OslcPropertyDefinition(Oslc_qmDomainConstants.QUALITY_MANAGEMENT_NAMSPACE + "validatesRequirementCollection")
@@ -202,7 +202,7 @@ public interface ITestPlan
     @OslcRepresentation(Representation.Reference)
     @OslcRange({Oslc_rmDomainConstants.REQUIREMENTCOLLECTION_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getValidatesRequirementCollection();
+    public Set<Link> getValidatesRequirementCollection();
 
     @OslcName("relatedChangeRequest")
     @OslcPropertyDefinition(Oslc_qmDomainConstants.QUALITY_MANAGEMENT_NAMSPACE + "relatedChangeRequest")
@@ -212,22 +212,22 @@ public interface ITestPlan
     @OslcRepresentation(Representation.Reference)
     @OslcRange({Oslc_cmDomainConstants.CHANGEREQUEST_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getRelatedChangeRequest();
+    public Set<Link> getRelatedChangeRequest();
 
 
-    public void setContributor(final HashSet<Link> contributor );
+    public void setContributor(final Set<Link> contributor );
     public void setCreated(final Date created );
-    public void setCreator(final HashSet<Link> creator );
+    public void setCreator(final Set<Link> creator );
     public void setDescription(final String description );
     public void setIdentifier(final String identifier );
     public void setModified(final Date modified );
-    public void setSubject(final HashSet<String> subject );
+    public void setSubject(final Set<String> subject );
     public void setTitle(final String title );
-    public void setType(final HashSet<Link> type );
+    public void setType(final Set<Link> type );
     public void setInstanceShape(final URI instanceShape );
-    public void setServiceProvider(final HashSet<URI> serviceProvider );
-    public void setUsesTestCase(final HashSet<Link> usesTestCase );
-    public void setValidatesRequirementCollection(final HashSet<Link> validatesRequirementCollection );
-    public void setRelatedChangeRequest(final HashSet<Link> relatedChangeRequest );
+    public void setServiceProvider(final Set<URI> serviceProvider );
+    public void setUsesTestCase(final Set<Link> usesTestCase );
+    public void setValidatesRequirementCollection(final Set<Link> validatesRequirementCollection );
+    public void setRelatedChangeRequest(final Set<Link> relatedChangeRequest );
 }
 

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/ITestResult.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/ITestResult.java
@@ -134,14 +134,14 @@ public interface ITestResult
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType();
+    public Set<Link> getType();
 
     @OslcName("serviceProvider")
     @OslcPropertyDefinition(OslcDomainConstants.OSLC_NAMSPACE + "serviceProvider")
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider();
+    public Set<URI> getServiceProvider();
 
     @OslcName("status")
     @OslcPropertyDefinition(Oslc_qmDomainConstants.QUALITY_MANAGEMENT_NAMSPACE + "status")
@@ -159,7 +159,7 @@ public interface ITestResult
     @OslcRepresentation(Representation.Reference)
     @OslcRange({Oslc_cmDomainConstants.CHANGEREQUEST_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getAffectedByChangeRequest();
+    public Set<Link> getAffectedByChangeRequest();
 
     @OslcName("executesTestScript")
     @OslcPropertyDefinition(Oslc_qmDomainConstants.QUALITY_MANAGEMENT_NAMSPACE + "executesTestScript")
@@ -205,10 +205,10 @@ public interface ITestResult
     public void setModified(final Date modified );
     public void setInstanceShape(final URI instanceShape );
     public void setTitle(final String title );
-    public void setType(final HashSet<Link> type );
-    public void setServiceProvider(final HashSet<URI> serviceProvider );
+    public void setType(final Set<Link> type );
+    public void setServiceProvider(final Set<URI> serviceProvider );
     public void setStatus(final String status );
-    public void setAffectedByChangeRequest(final HashSet<Link> affectedByChangeRequest );
+    public void setAffectedByChangeRequest(final Set<Link> affectedByChangeRequest );
     public void setExecutesTestScript(final Link executesTestScript );
     public void setProducedByTestExecutionRecord(final Link producedByTestExecutionRecord );
     public void setReportsOnTestCase(final Link reportsOnTestCase );

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/ITestScript.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/ITestScript.java
@@ -101,7 +101,7 @@ public interface ITestScript
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor();
+    public Set<Link> getContributor();
 
     @OslcName("created")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "created")
@@ -118,7 +118,7 @@ public interface ITestScript
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator();
+    public Set<Link> getCreator();
 
     @OslcName("description")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "description")
@@ -156,7 +156,7 @@ public interface ITestScript
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider();
+    public Set<URI> getServiceProvider();
 
     @OslcName("title")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "title")
@@ -172,7 +172,7 @@ public interface ITestScript
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType();
+    public Set<Link> getType();
 
     @OslcName("executionInstructions")
     @OslcPropertyDefinition(Oslc_qmDomainConstants.QUALITY_MANAGEMENT_NAMSPACE + "executionInstructions")
@@ -181,7 +181,7 @@ public interface ITestScript
     @OslcValueType(ValueType.Resource)
     @OslcRepresentation(Representation.Reference)
     @OslcReadOnly(false)
-    public HashSet<Link> getExecutionInstructions();
+    public Set<Link> getExecutionInstructions();
 
     @OslcName("relatedChangeRequest")
     @OslcPropertyDefinition(Oslc_qmDomainConstants.QUALITY_MANAGEMENT_NAMSPACE + "relatedChangeRequest")
@@ -191,7 +191,7 @@ public interface ITestScript
     @OslcRepresentation(Representation.Reference)
     @OslcRange({Oslc_cmDomainConstants.CHANGEREQUEST_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getRelatedChangeRequest();
+    public Set<Link> getRelatedChangeRequest();
 
     @OslcName("validatesRequirement")
     @OslcPropertyDefinition(Oslc_qmDomainConstants.QUALITY_MANAGEMENT_NAMSPACE + "validatesRequirement")
@@ -201,21 +201,21 @@ public interface ITestScript
     @OslcRepresentation(Representation.Reference)
     @OslcRange({Oslc_rmDomainConstants.REQUIREMENT_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getValidatesRequirement();
+    public Set<Link> getValidatesRequirement();
 
 
-    public void setContributor(final HashSet<Link> contributor );
+    public void setContributor(final Set<Link> contributor );
     public void setCreated(final Date created );
-    public void setCreator(final HashSet<Link> creator );
+    public void setCreator(final Set<Link> creator );
     public void setDescription(final String description );
     public void setIdentifier(final String identifier );
     public void setModified(final Date modified );
     public void setInstanceShape(final URI instanceShape );
-    public void setServiceProvider(final HashSet<URI> serviceProvider );
+    public void setServiceProvider(final Set<URI> serviceProvider );
     public void setTitle(final String title );
-    public void setType(final HashSet<Link> type );
-    public void setExecutionInstructions(final HashSet<Link> executionInstructions );
-    public void setRelatedChangeRequest(final HashSet<Link> relatedChangeRequest );
-    public void setValidatesRequirement(final HashSet<Link> validatesRequirement );
+    public void setType(final Set<Link> type );
+    public void setExecutionInstructions(final Set<Link> executionInstructions );
+    public void setRelatedChangeRequest(final Set<Link> relatedChangeRequest );
+    public void setValidatesRequirement(final Set<Link> validatesRequirement );
 }
 

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestCase.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestCase.java
@@ -104,13 +104,13 @@ public class TestCase
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private HashSet<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<Link>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private HashSet<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<Link>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -125,28 +125,28 @@ public class TestCase
     private URI instanceShape;
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private HashSet<URI> serviceProvider = new HashSet<URI>();
+    private Set<URI> serviceProvider = new HashSet<URI>();
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private HashSet<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<String>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private HashSet<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<Link>();
     // Start of user code attributeAnnotation:relatedChangeRequest
     // End of user code
-    private HashSet<Link> relatedChangeRequest = new HashSet<Link>();
+    private Set<Link> relatedChangeRequest = new HashSet<Link>();
     // Start of user code attributeAnnotation:testsChangeRequest
     // End of user code
-    private HashSet<Link> testsChangeRequest = new HashSet<Link>();
+    private Set<Link> testsChangeRequest = new HashSet<Link>();
     // Start of user code attributeAnnotation:usesTestScript
     // End of user code
-    private HashSet<Link> usesTestScript = new HashSet<Link>();
+    private Set<Link> usesTestScript = new HashSet<Link>();
     // Start of user code attributeAnnotation:validatesRequirement
     // End of user code
-    private HashSet<Link> validatesRequirement = new HashSet<Link>();
+    private Set<Link> validatesRequirement = new HashSet<Link>();
     
     // Start of user code classAttributes
     // End of user code
@@ -205,11 +205,13 @@ public class TestCase
         return result;
     }
     
+    @Deprecated
     public String toHtml()
     {
         return toHtml(false);
     }
     
+    @Deprecated
     public String toHtml(boolean asLocalResource)
     {
         String result = "";
@@ -286,7 +288,7 @@ public class TestCase
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor()
+    public Set<Link> getContributor()
     {
         // Start of user code getterInit:contributor
         // End of user code
@@ -317,7 +319,7 @@ public class TestCase
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator()
+    public Set<Link> getCreator()
     {
         // Start of user code getterInit:creator
         // End of user code
@@ -390,7 +392,7 @@ public class TestCase
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider()
+    public Set<URI> getServiceProvider()
     {
         // Start of user code getterInit:serviceProvider
         // End of user code
@@ -406,7 +408,7 @@ public class TestCase
     @OslcValueType(ValueType.String)
     @OslcReadOnly(false)
     @OslcTitle("")
-    public HashSet<String> getSubject()
+    public Set<String> getSubject()
     {
         // Start of user code getterInit:subject
         // End of user code
@@ -436,7 +438,7 @@ public class TestCase
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType()
+    public Set<Link> getType()
     {
         // Start of user code getterInit:type
         // End of user code
@@ -453,7 +455,7 @@ public class TestCase
     @OslcRepresentation(Representation.Reference)
     @OslcRange({Oslc_cmDomainConstants.CHANGEREQUEST_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getRelatedChangeRequest()
+    public Set<Link> getRelatedChangeRequest()
     {
         // Start of user code getterInit:relatedChangeRequest
         // End of user code
@@ -470,7 +472,7 @@ public class TestCase
     @OslcRepresentation(Representation.Reference)
     @OslcRange({Oslc_cmDomainConstants.CHANGEREQUEST_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getTestsChangeRequest()
+    public Set<Link> getTestsChangeRequest()
     {
         // Start of user code getterInit:testsChangeRequest
         // End of user code
@@ -486,7 +488,7 @@ public class TestCase
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_qmDomainConstants.TESTSCRIPT_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getUsesTestScript()
+    public Set<Link> getUsesTestScript()
     {
         // Start of user code getterInit:usesTestScript
         // End of user code
@@ -503,7 +505,7 @@ public class TestCase
     @OslcRepresentation(Representation.Reference)
     @OslcRange({Oslc_rmDomainConstants.REQUIREMENT_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getValidatesRequirement()
+    public Set<Link> getValidatesRequirement()
     {
         // Start of user code getterInit:validatesRequirement
         // End of user code
@@ -513,7 +515,7 @@ public class TestCase
     
     // Start of user code setterAnnotation:contributor
     // End of user code
-    public void setContributor(final HashSet<Link> contributor )
+    public void setContributor(final Set<Link> contributor )
     {
         // Start of user code setterInit:contributor
         // End of user code
@@ -541,7 +543,7 @@ public class TestCase
     
     // Start of user code setterAnnotation:creator
     // End of user code
-    public void setCreator(final HashSet<Link> creator )
+    public void setCreator(final Set<Link> creator )
     {
         // Start of user code setterInit:creator
         // End of user code
@@ -605,7 +607,7 @@ public class TestCase
     
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
-    public void setServiceProvider(final HashSet<URI> serviceProvider )
+    public void setServiceProvider(final Set<URI> serviceProvider )
     {
         // Start of user code setterInit:serviceProvider
         // End of user code
@@ -621,7 +623,7 @@ public class TestCase
     
     // Start of user code setterAnnotation:subject
     // End of user code
-    public void setSubject(final HashSet<String> subject )
+    public void setSubject(final Set<String> subject )
     {
         // Start of user code setterInit:subject
         // End of user code
@@ -649,7 +651,7 @@ public class TestCase
     
     // Start of user code setterAnnotation:type
     // End of user code
-    public void setType(final HashSet<Link> type )
+    public void setType(final Set<Link> type )
     {
         // Start of user code setterInit:type
         // End of user code
@@ -665,7 +667,7 @@ public class TestCase
     
     // Start of user code setterAnnotation:relatedChangeRequest
     // End of user code
-    public void setRelatedChangeRequest(final HashSet<Link> relatedChangeRequest )
+    public void setRelatedChangeRequest(final Set<Link> relatedChangeRequest )
     {
         // Start of user code setterInit:relatedChangeRequest
         // End of user code
@@ -681,7 +683,7 @@ public class TestCase
     
     // Start of user code setterAnnotation:testsChangeRequest
     // End of user code
-    public void setTestsChangeRequest(final HashSet<Link> testsChangeRequest )
+    public void setTestsChangeRequest(final Set<Link> testsChangeRequest )
     {
         // Start of user code setterInit:testsChangeRequest
         // End of user code
@@ -697,7 +699,7 @@ public class TestCase
     
     // Start of user code setterAnnotation:usesTestScript
     // End of user code
-    public void setUsesTestScript(final HashSet<Link> usesTestScript )
+    public void setUsesTestScript(final Set<Link> usesTestScript )
     {
         // Start of user code setterInit:usesTestScript
         // End of user code
@@ -713,7 +715,7 @@ public class TestCase
     
     // Start of user code setterAnnotation:validatesRequirement
     // End of user code
-    public void setValidatesRequirement(final HashSet<Link> validatesRequirement )
+    public void setValidatesRequirement(final Set<Link> validatesRequirement )
     {
         // Start of user code setterInit:validatesRequirement
         // End of user code
@@ -728,6 +730,7 @@ public class TestCase
     }
     
     
+    @Deprecated
     static public String contributorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -746,6 +749,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     static public String createdToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -765,6 +769,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     static public String creatorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -783,6 +788,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     static public String descriptionToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -802,6 +808,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     static public String identifierToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -821,6 +828,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     static public String modifiedToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -840,6 +848,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     static public String instanceShapeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -859,6 +868,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     static public String serviceProviderToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -878,6 +888,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     static public String subjectToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -897,6 +908,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     static public String titleToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -916,6 +928,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     static public String typeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -934,6 +947,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     static public String relatedChangeRequestToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -952,6 +966,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     static public String testsChangeRequestToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -970,6 +985,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     static public String usesTestScriptToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -988,6 +1004,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     static public String validatesRequirementToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1007,6 +1024,7 @@ public class TestCase
     }
     
     
+    @Deprecated
     public String contributorToHtml()
     {
         String s = "";
@@ -1032,6 +1050,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     public String createdToHtml()
     {
         String s = "";
@@ -1056,6 +1075,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     public String creatorToHtml()
     {
         String s = "";
@@ -1081,6 +1101,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     public String descriptionToHtml()
     {
         String s = "";
@@ -1105,6 +1126,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     public String identifierToHtml()
     {
         String s = "";
@@ -1129,6 +1151,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     public String modifiedToHtml()
     {
         String s = "";
@@ -1153,6 +1176,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     public String instanceShapeToHtml()
     {
         String s = "";
@@ -1177,6 +1201,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     public String serviceProviderToHtml()
     {
         String s = "";
@@ -1203,6 +1228,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     public String subjectToHtml()
     {
         String s = "";
@@ -1229,6 +1255,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     public String titleToHtml()
     {
         String s = "";
@@ -1253,6 +1280,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     public String typeToHtml()
     {
         String s = "";
@@ -1283,6 +1311,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     public String relatedChangeRequestToHtml()
     {
         String s = "";
@@ -1308,6 +1337,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     public String testsChangeRequestToHtml()
     {
         String s = "";
@@ -1333,6 +1363,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     public String usesTestScriptToHtml()
     {
         String s = "";
@@ -1358,6 +1389,7 @@ public class TestCase
         return s;
     }
     
+    @Deprecated
     public String validatesRequirementToHtml()
     {
         String s = "";

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestExecutionRecord.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestExecutionRecord.java
@@ -103,13 +103,13 @@ public class TestExecutionRecord
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private HashSet<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<Link>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private HashSet<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<Link>();
     // Start of user code attributeAnnotation:identifier
     // End of user code
     private String identifier;
@@ -118,31 +118,31 @@ public class TestExecutionRecord
     private Date modified;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private HashSet<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<Link>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
     private URI instanceShape;
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private HashSet<URI> serviceProvider = new HashSet<URI>();
+    private Set<URI> serviceProvider = new HashSet<URI>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
     // Start of user code attributeAnnotation:blockedByChangeRequest
     // End of user code
-    private HashSet<Link> blockedByChangeRequest = new HashSet<Link>();
+    private Set<Link> blockedByChangeRequest = new HashSet<Link>();
     // Start of user code attributeAnnotation:relatedChangeRequest
     // End of user code
-    private HashSet<Link> relatedChangeRequest = new HashSet<Link>();
+    private Set<Link> relatedChangeRequest = new HashSet<Link>();
     // Start of user code attributeAnnotation:reportsOnTestPlan
     // End of user code
-    private Link reportsOnTestPlan = new Link();
+    private Link reportsOnTestPlan;
     // Start of user code attributeAnnotation:runsOnTestEnvironment
     // End of user code
-    private Link runsOnTestEnvironment = new Link();
+    private Link runsOnTestEnvironment;
     // Start of user code attributeAnnotation:runsTestCase
     // End of user code
-    private Link runsTestCase = new Link();
+    private Link runsTestCase;
     
     // Start of user code classAttributes
     // End of user code
@@ -201,11 +201,13 @@ public class TestExecutionRecord
         return result;
     }
     
+    @Deprecated
     public String toHtml()
     {
         return toHtml(false);
     }
     
+    @Deprecated
     public String toHtml(boolean asLocalResource)
     {
         String result = "";
@@ -267,7 +269,7 @@ public class TestExecutionRecord
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor()
+    public Set<Link> getContributor()
     {
         // Start of user code getterInit:contributor
         // End of user code
@@ -298,7 +300,7 @@ public class TestExecutionRecord
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator()
+    public Set<Link> getCreator()
     {
         // Start of user code getterInit:creator
         // End of user code
@@ -343,7 +345,7 @@ public class TestExecutionRecord
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType()
+    public Set<Link> getType()
     {
         // Start of user code getterInit:type
         // End of user code
@@ -371,7 +373,7 @@ public class TestExecutionRecord
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider()
+    public Set<URI> getServiceProvider()
     {
         // Start of user code getterInit:serviceProvider
         // End of user code
@@ -403,7 +405,7 @@ public class TestExecutionRecord
     @OslcRepresentation(Representation.Reference)
     @OslcRange({Oslc_cmDomainConstants.CHANGEREQUEST_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getBlockedByChangeRequest()
+    public Set<Link> getBlockedByChangeRequest()
     {
         // Start of user code getterInit:blockedByChangeRequest
         // End of user code
@@ -420,7 +422,7 @@ public class TestExecutionRecord
     @OslcRepresentation(Representation.Reference)
     @OslcRange({Oslc_cmDomainConstants.CHANGEREQUEST_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getRelatedChangeRequest()
+    public Set<Link> getRelatedChangeRequest()
     {
         // Start of user code getterInit:relatedChangeRequest
         // End of user code
@@ -478,7 +480,7 @@ public class TestExecutionRecord
     
     // Start of user code setterAnnotation:contributor
     // End of user code
-    public void setContributor(final HashSet<Link> contributor )
+    public void setContributor(final Set<Link> contributor )
     {
         // Start of user code setterInit:contributor
         // End of user code
@@ -506,7 +508,7 @@ public class TestExecutionRecord
     
     // Start of user code setterAnnotation:creator
     // End of user code
-    public void setCreator(final HashSet<Link> creator )
+    public void setCreator(final Set<Link> creator )
     {
         // Start of user code setterInit:creator
         // End of user code
@@ -546,7 +548,7 @@ public class TestExecutionRecord
     
     // Start of user code setterAnnotation:type
     // End of user code
-    public void setType(final HashSet<Link> type )
+    public void setType(final Set<Link> type )
     {
         // Start of user code setterInit:type
         // End of user code
@@ -574,7 +576,7 @@ public class TestExecutionRecord
     
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
-    public void setServiceProvider(final HashSet<URI> serviceProvider )
+    public void setServiceProvider(final Set<URI> serviceProvider )
     {
         // Start of user code setterInit:serviceProvider
         // End of user code
@@ -602,7 +604,7 @@ public class TestExecutionRecord
     
     // Start of user code setterAnnotation:blockedByChangeRequest
     // End of user code
-    public void setBlockedByChangeRequest(final HashSet<Link> blockedByChangeRequest )
+    public void setBlockedByChangeRequest(final Set<Link> blockedByChangeRequest )
     {
         // Start of user code setterInit:blockedByChangeRequest
         // End of user code
@@ -618,7 +620,7 @@ public class TestExecutionRecord
     
     // Start of user code setterAnnotation:relatedChangeRequest
     // End of user code
-    public void setRelatedChangeRequest(final HashSet<Link> relatedChangeRequest )
+    public void setRelatedChangeRequest(final Set<Link> relatedChangeRequest )
     {
         // Start of user code setterInit:relatedChangeRequest
         // End of user code
@@ -669,6 +671,7 @@ public class TestExecutionRecord
     }
     
     
+    @Deprecated
     static public String contributorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -687,6 +690,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     static public String createdToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -706,6 +710,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     static public String creatorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -724,6 +729,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     static public String identifierToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -743,6 +749,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     static public String modifiedToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -762,6 +769,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     static public String typeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -780,6 +788,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     static public String instanceShapeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -799,6 +808,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     static public String serviceProviderToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -818,6 +828,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     static public String titleToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -837,6 +848,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     static public String blockedByChangeRequestToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -855,6 +867,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     static public String relatedChangeRequestToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -873,6 +886,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     static public String reportsOnTestPlanToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -891,6 +905,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     static public String runsOnTestEnvironmentToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -909,6 +924,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     static public String runsTestCaseToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -928,6 +944,7 @@ public class TestExecutionRecord
     }
     
     
+    @Deprecated
     public String contributorToHtml()
     {
         String s = "";
@@ -953,6 +970,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     public String createdToHtml()
     {
         String s = "";
@@ -977,6 +995,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     public String creatorToHtml()
     {
         String s = "";
@@ -1002,6 +1021,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     public String identifierToHtml()
     {
         String s = "";
@@ -1026,6 +1046,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     public String modifiedToHtml()
     {
         String s = "";
@@ -1050,6 +1071,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     public String typeToHtml()
     {
         String s = "";
@@ -1080,6 +1102,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     public String instanceShapeToHtml()
     {
         String s = "";
@@ -1104,6 +1127,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     public String serviceProviderToHtml()
     {
         String s = "";
@@ -1130,6 +1154,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     public String titleToHtml()
     {
         String s = "";
@@ -1154,6 +1179,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     public String blockedByChangeRequestToHtml()
     {
         String s = "";
@@ -1179,6 +1205,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     public String relatedChangeRequestToHtml()
     {
         String s = "";
@@ -1204,6 +1231,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     public String reportsOnTestPlanToHtml()
     {
         String s = "";
@@ -1228,6 +1256,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     public String runsOnTestEnvironmentToHtml()
     {
         String s = "";
@@ -1252,6 +1281,7 @@ public class TestExecutionRecord
         return s;
     }
     
+    @Deprecated
     public String runsTestCaseToHtml()
     {
         String s = "";

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestPlan.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestPlan.java
@@ -103,13 +103,13 @@ public class TestPlan
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private HashSet<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<Link>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private HashSet<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<Link>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -121,28 +121,28 @@ public class TestPlan
     private Date modified;
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private HashSet<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<String>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private HashSet<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<Link>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
     private URI instanceShape;
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private HashSet<URI> serviceProvider = new HashSet<URI>();
+    private Set<URI> serviceProvider = new HashSet<URI>();
     // Start of user code attributeAnnotation:usesTestCase
     // End of user code
-    private HashSet<Link> usesTestCase = new HashSet<Link>();
+    private Set<Link> usesTestCase = new HashSet<Link>();
     // Start of user code attributeAnnotation:validatesRequirementCollection
     // End of user code
-    private HashSet<Link> validatesRequirementCollection = new HashSet<Link>();
+    private Set<Link> validatesRequirementCollection = new HashSet<Link>();
     // Start of user code attributeAnnotation:relatedChangeRequest
     // End of user code
-    private HashSet<Link> relatedChangeRequest = new HashSet<Link>();
+    private Set<Link> relatedChangeRequest = new HashSet<Link>();
     
     // Start of user code classAttributes
     // End of user code
@@ -201,11 +201,13 @@ public class TestPlan
         return result;
     }
     
+    @Deprecated
     public String toHtml()
     {
         return toHtml(false);
     }
     
+    @Deprecated
     public String toHtml(boolean asLocalResource)
     {
         String result = "";
@@ -277,7 +279,7 @@ public class TestPlan
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor()
+    public Set<Link> getContributor()
     {
         // Start of user code getterInit:contributor
         // End of user code
@@ -308,7 +310,7 @@ public class TestPlan
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator()
+    public Set<Link> getCreator()
     {
         // Start of user code getterInit:creator
         // End of user code
@@ -369,7 +371,7 @@ public class TestPlan
     @OslcValueType(ValueType.String)
     @OslcReadOnly(false)
     @OslcTitle("")
-    public HashSet<String> getSubject()
+    public Set<String> getSubject()
     {
         // Start of user code getterInit:subject
         // End of user code
@@ -399,7 +401,7 @@ public class TestPlan
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType()
+    public Set<Link> getType()
     {
         // Start of user code getterInit:type
         // End of user code
@@ -427,7 +429,7 @@ public class TestPlan
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider()
+    public Set<URI> getServiceProvider()
     {
         // Start of user code getterInit:serviceProvider
         // End of user code
@@ -443,7 +445,7 @@ public class TestPlan
     @OslcValueType(ValueType.Resource)
     @OslcRange({Oslc_qmDomainConstants.TESTCASE_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getUsesTestCase()
+    public Set<Link> getUsesTestCase()
     {
         // Start of user code getterInit:usesTestCase
         // End of user code
@@ -460,7 +462,7 @@ public class TestPlan
     @OslcRepresentation(Representation.Reference)
     @OslcRange({Oslc_rmDomainConstants.REQUIREMENTCOLLECTION_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getValidatesRequirementCollection()
+    public Set<Link> getValidatesRequirementCollection()
     {
         // Start of user code getterInit:validatesRequirementCollection
         // End of user code
@@ -477,7 +479,7 @@ public class TestPlan
     @OslcRepresentation(Representation.Reference)
     @OslcRange({Oslc_cmDomainConstants.CHANGEREQUEST_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getRelatedChangeRequest()
+    public Set<Link> getRelatedChangeRequest()
     {
         // Start of user code getterInit:relatedChangeRequest
         // End of user code
@@ -487,7 +489,7 @@ public class TestPlan
     
     // Start of user code setterAnnotation:contributor
     // End of user code
-    public void setContributor(final HashSet<Link> contributor )
+    public void setContributor(final Set<Link> contributor )
     {
         // Start of user code setterInit:contributor
         // End of user code
@@ -515,7 +517,7 @@ public class TestPlan
     
     // Start of user code setterAnnotation:creator
     // End of user code
-    public void setCreator(final HashSet<Link> creator )
+    public void setCreator(final Set<Link> creator )
     {
         // Start of user code setterInit:creator
         // End of user code
@@ -567,7 +569,7 @@ public class TestPlan
     
     // Start of user code setterAnnotation:subject
     // End of user code
-    public void setSubject(final HashSet<String> subject )
+    public void setSubject(final Set<String> subject )
     {
         // Start of user code setterInit:subject
         // End of user code
@@ -595,7 +597,7 @@ public class TestPlan
     
     // Start of user code setterAnnotation:type
     // End of user code
-    public void setType(final HashSet<Link> type )
+    public void setType(final Set<Link> type )
     {
         // Start of user code setterInit:type
         // End of user code
@@ -623,7 +625,7 @@ public class TestPlan
     
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
-    public void setServiceProvider(final HashSet<URI> serviceProvider )
+    public void setServiceProvider(final Set<URI> serviceProvider )
     {
         // Start of user code setterInit:serviceProvider
         // End of user code
@@ -639,7 +641,7 @@ public class TestPlan
     
     // Start of user code setterAnnotation:usesTestCase
     // End of user code
-    public void setUsesTestCase(final HashSet<Link> usesTestCase )
+    public void setUsesTestCase(final Set<Link> usesTestCase )
     {
         // Start of user code setterInit:usesTestCase
         // End of user code
@@ -655,7 +657,7 @@ public class TestPlan
     
     // Start of user code setterAnnotation:validatesRequirementCollection
     // End of user code
-    public void setValidatesRequirementCollection(final HashSet<Link> validatesRequirementCollection )
+    public void setValidatesRequirementCollection(final Set<Link> validatesRequirementCollection )
     {
         // Start of user code setterInit:validatesRequirementCollection
         // End of user code
@@ -671,7 +673,7 @@ public class TestPlan
     
     // Start of user code setterAnnotation:relatedChangeRequest
     // End of user code
-    public void setRelatedChangeRequest(final HashSet<Link> relatedChangeRequest )
+    public void setRelatedChangeRequest(final Set<Link> relatedChangeRequest )
     {
         // Start of user code setterInit:relatedChangeRequest
         // End of user code
@@ -686,6 +688,7 @@ public class TestPlan
     }
     
     
+    @Deprecated
     static public String contributorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -704,6 +707,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     static public String createdToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -723,6 +727,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     static public String creatorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -741,6 +746,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     static public String descriptionToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -760,6 +766,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     static public String identifierToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -779,6 +786,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     static public String modifiedToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -798,6 +806,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     static public String subjectToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -817,6 +826,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     static public String titleToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -836,6 +846,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     static public String typeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -854,6 +865,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     static public String instanceShapeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -873,6 +885,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     static public String serviceProviderToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -892,6 +905,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     static public String usesTestCaseToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -910,6 +924,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     static public String validatesRequirementCollectionToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -928,6 +943,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     static public String relatedChangeRequestToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -947,6 +963,7 @@ public class TestPlan
     }
     
     
+    @Deprecated
     public String contributorToHtml()
     {
         String s = "";
@@ -972,6 +989,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     public String createdToHtml()
     {
         String s = "";
@@ -996,6 +1014,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     public String creatorToHtml()
     {
         String s = "";
@@ -1021,6 +1040,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     public String descriptionToHtml()
     {
         String s = "";
@@ -1045,6 +1065,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     public String identifierToHtml()
     {
         String s = "";
@@ -1069,6 +1090,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     public String modifiedToHtml()
     {
         String s = "";
@@ -1093,6 +1115,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     public String subjectToHtml()
     {
         String s = "";
@@ -1119,6 +1142,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     public String titleToHtml()
     {
         String s = "";
@@ -1143,6 +1167,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     public String typeToHtml()
     {
         String s = "";
@@ -1173,6 +1198,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     public String instanceShapeToHtml()
     {
         String s = "";
@@ -1197,6 +1223,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     public String serviceProviderToHtml()
     {
         String s = "";
@@ -1223,6 +1250,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     public String usesTestCaseToHtml()
     {
         String s = "";
@@ -1248,6 +1276,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     public String validatesRequirementCollectionToHtml()
     {
         String s = "";
@@ -1273,6 +1302,7 @@ public class TestPlan
         return s;
     }
     
+    @Deprecated
     public String relatedChangeRequestToHtml()
     {
         String s = "";

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestResult.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestResult.java
@@ -116,28 +116,28 @@ public class TestResult
     private String title;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private HashSet<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<Link>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private HashSet<URI> serviceProvider = new HashSet<URI>();
+    private Set<URI> serviceProvider = new HashSet<URI>();
     // Start of user code attributeAnnotation:status
     // End of user code
     private String status;
     // Start of user code attributeAnnotation:affectedByChangeRequest
     // End of user code
-    private HashSet<Link> affectedByChangeRequest = new HashSet<Link>();
+    private Set<Link> affectedByChangeRequest = new HashSet<Link>();
     // Start of user code attributeAnnotation:executesTestScript
     // End of user code
-    private Link executesTestScript = new Link();
+    private Link executesTestScript;
     // Start of user code attributeAnnotation:producedByTestExecutionRecord
     // End of user code
-    private Link producedByTestExecutionRecord = new Link();
+    private Link producedByTestExecutionRecord;
     // Start of user code attributeAnnotation:reportsOnTestCase
     // End of user code
-    private Link reportsOnTestCase = new Link();
+    private Link reportsOnTestCase;
     // Start of user code attributeAnnotation:reportsOnTestPlan
     // End of user code
-    private Link reportsOnTestPlan = new Link();
+    private Link reportsOnTestPlan;
     
     // Start of user code classAttributes
     // End of user code
@@ -196,11 +196,13 @@ public class TestResult
         return result;
     }
     
+    @Deprecated
     public String toHtml()
     {
         return toHtml(false);
     }
     
+    @Deprecated
     public String toHtml(boolean asLocalResource)
     {
         String result = "";
@@ -320,7 +322,7 @@ public class TestResult
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType()
+    public Set<Link> getType()
     {
         // Start of user code getterInit:type
         // End of user code
@@ -334,7 +336,7 @@ public class TestResult
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider()
+    public Set<URI> getServiceProvider()
     {
         // Start of user code getterInit:serviceProvider
         // End of user code
@@ -366,7 +368,7 @@ public class TestResult
     @OslcRepresentation(Representation.Reference)
     @OslcRange({Oslc_cmDomainConstants.CHANGEREQUEST_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getAffectedByChangeRequest()
+    public Set<Link> getAffectedByChangeRequest()
     {
         // Start of user code getterInit:affectedByChangeRequest
         // End of user code
@@ -502,7 +504,7 @@ public class TestResult
     
     // Start of user code setterAnnotation:type
     // End of user code
-    public void setType(final HashSet<Link> type )
+    public void setType(final Set<Link> type )
     {
         // Start of user code setterInit:type
         // End of user code
@@ -518,7 +520,7 @@ public class TestResult
     
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
-    public void setServiceProvider(final HashSet<URI> serviceProvider )
+    public void setServiceProvider(final Set<URI> serviceProvider )
     {
         // Start of user code setterInit:serviceProvider
         // End of user code
@@ -546,7 +548,7 @@ public class TestResult
     
     // Start of user code setterAnnotation:affectedByChangeRequest
     // End of user code
-    public void setAffectedByChangeRequest(final HashSet<Link> affectedByChangeRequest )
+    public void setAffectedByChangeRequest(final Set<Link> affectedByChangeRequest )
     {
         // Start of user code setterInit:affectedByChangeRequest
         // End of user code
@@ -609,6 +611,7 @@ public class TestResult
     }
     
     
+    @Deprecated
     static public String createdToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -628,6 +631,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     static public String identifierToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -647,6 +651,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     static public String modifiedToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -666,6 +671,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     static public String instanceShapeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -685,6 +691,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     static public String titleToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -704,6 +711,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     static public String typeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -722,6 +730,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     static public String serviceProviderToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -741,6 +750,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     static public String statusToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -760,6 +770,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     static public String affectedByChangeRequestToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -778,6 +789,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     static public String executesTestScriptToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -796,6 +808,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     static public String producedByTestExecutionRecordToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -814,6 +827,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     static public String reportsOnTestCaseToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -832,6 +846,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     static public String reportsOnTestPlanToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -851,6 +866,7 @@ public class TestResult
     }
     
     
+    @Deprecated
     public String createdToHtml()
     {
         String s = "";
@@ -875,6 +891,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     public String identifierToHtml()
     {
         String s = "";
@@ -899,6 +916,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     public String modifiedToHtml()
     {
         String s = "";
@@ -923,6 +941,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     public String instanceShapeToHtml()
     {
         String s = "";
@@ -947,6 +966,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     public String titleToHtml()
     {
         String s = "";
@@ -971,6 +991,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     public String typeToHtml()
     {
         String s = "";
@@ -1001,6 +1022,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     public String serviceProviderToHtml()
     {
         String s = "";
@@ -1027,6 +1049,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     public String statusToHtml()
     {
         String s = "";
@@ -1051,6 +1074,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     public String affectedByChangeRequestToHtml()
     {
         String s = "";
@@ -1076,6 +1100,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     public String executesTestScriptToHtml()
     {
         String s = "";
@@ -1100,6 +1125,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     public String producedByTestExecutionRecordToHtml()
     {
         String s = "";
@@ -1124,6 +1150,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     public String reportsOnTestCaseToHtml()
     {
         String s = "";
@@ -1148,6 +1175,7 @@ public class TestResult
         return s;
     }
     
+    @Deprecated
     public String reportsOnTestPlanToHtml()
     {
         String s = "";

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestScript.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestScript.java
@@ -102,13 +102,13 @@ public class TestScript
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private HashSet<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<Link>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private HashSet<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<Link>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -123,22 +123,22 @@ public class TestScript
     private URI instanceShape;
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private HashSet<URI> serviceProvider = new HashSet<URI>();
+    private Set<URI> serviceProvider = new HashSet<URI>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private HashSet<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<Link>();
     // Start of user code attributeAnnotation:executionInstructions
     // End of user code
-    private HashSet<Link> executionInstructions = new HashSet<Link>();
+    private Set<Link> executionInstructions = new HashSet<Link>();
     // Start of user code attributeAnnotation:relatedChangeRequest
     // End of user code
-    private HashSet<Link> relatedChangeRequest = new HashSet<Link>();
+    private Set<Link> relatedChangeRequest = new HashSet<Link>();
     // Start of user code attributeAnnotation:validatesRequirement
     // End of user code
-    private HashSet<Link> validatesRequirement = new HashSet<Link>();
+    private Set<Link> validatesRequirement = new HashSet<Link>();
     
     // Start of user code classAttributes
     // End of user code
@@ -197,11 +197,13 @@ public class TestScript
         return result;
     }
     
+    @Deprecated
     public String toHtml()
     {
         return toHtml(false);
     }
     
+    @Deprecated
     public String toHtml(boolean asLocalResource)
     {
         String result = "";
@@ -268,7 +270,7 @@ public class TestScript
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor()
+    public Set<Link> getContributor()
     {
         // Start of user code getterInit:contributor
         // End of user code
@@ -299,7 +301,7 @@ public class TestScript
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator()
+    public Set<Link> getCreator()
     {
         // Start of user code getterInit:creator
         // End of user code
@@ -372,7 +374,7 @@ public class TestScript
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider()
+    public Set<URI> getServiceProvider()
     {
         // Start of user code getterInit:serviceProvider
         // End of user code
@@ -402,7 +404,7 @@ public class TestScript
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType()
+    public Set<Link> getType()
     {
         // Start of user code getterInit:type
         // End of user code
@@ -418,7 +420,7 @@ public class TestScript
     @OslcValueType(ValueType.Resource)
     @OslcRepresentation(Representation.Reference)
     @OslcReadOnly(false)
-    public HashSet<Link> getExecutionInstructions()
+    public Set<Link> getExecutionInstructions()
     {
         // Start of user code getterInit:executionInstructions
         // End of user code
@@ -435,7 +437,7 @@ public class TestScript
     @OslcRepresentation(Representation.Reference)
     @OslcRange({Oslc_cmDomainConstants.CHANGEREQUEST_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getRelatedChangeRequest()
+    public Set<Link> getRelatedChangeRequest()
     {
         // Start of user code getterInit:relatedChangeRequest
         // End of user code
@@ -452,7 +454,7 @@ public class TestScript
     @OslcRepresentation(Representation.Reference)
     @OslcRange({Oslc_rmDomainConstants.REQUIREMENT_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getValidatesRequirement()
+    public Set<Link> getValidatesRequirement()
     {
         // Start of user code getterInit:validatesRequirement
         // End of user code
@@ -462,7 +464,7 @@ public class TestScript
     
     // Start of user code setterAnnotation:contributor
     // End of user code
-    public void setContributor(final HashSet<Link> contributor )
+    public void setContributor(final Set<Link> contributor )
     {
         // Start of user code setterInit:contributor
         // End of user code
@@ -490,7 +492,7 @@ public class TestScript
     
     // Start of user code setterAnnotation:creator
     // End of user code
-    public void setCreator(final HashSet<Link> creator )
+    public void setCreator(final Set<Link> creator )
     {
         // Start of user code setterInit:creator
         // End of user code
@@ -554,7 +556,7 @@ public class TestScript
     
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
-    public void setServiceProvider(final HashSet<URI> serviceProvider )
+    public void setServiceProvider(final Set<URI> serviceProvider )
     {
         // Start of user code setterInit:serviceProvider
         // End of user code
@@ -582,7 +584,7 @@ public class TestScript
     
     // Start of user code setterAnnotation:type
     // End of user code
-    public void setType(final HashSet<Link> type )
+    public void setType(final Set<Link> type )
     {
         // Start of user code setterInit:type
         // End of user code
@@ -598,7 +600,7 @@ public class TestScript
     
     // Start of user code setterAnnotation:executionInstructions
     // End of user code
-    public void setExecutionInstructions(final HashSet<Link> executionInstructions )
+    public void setExecutionInstructions(final Set<Link> executionInstructions )
     {
         // Start of user code setterInit:executionInstructions
         // End of user code
@@ -614,7 +616,7 @@ public class TestScript
     
     // Start of user code setterAnnotation:relatedChangeRequest
     // End of user code
-    public void setRelatedChangeRequest(final HashSet<Link> relatedChangeRequest )
+    public void setRelatedChangeRequest(final Set<Link> relatedChangeRequest )
     {
         // Start of user code setterInit:relatedChangeRequest
         // End of user code
@@ -630,7 +632,7 @@ public class TestScript
     
     // Start of user code setterAnnotation:validatesRequirement
     // End of user code
-    public void setValidatesRequirement(final HashSet<Link> validatesRequirement )
+    public void setValidatesRequirement(final Set<Link> validatesRequirement )
     {
         // Start of user code setterInit:validatesRequirement
         // End of user code
@@ -645,6 +647,7 @@ public class TestScript
     }
     
     
+    @Deprecated
     static public String contributorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -663,6 +666,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     static public String createdToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -682,6 +686,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     static public String creatorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -700,6 +705,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     static public String descriptionToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -719,6 +725,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     static public String identifierToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -738,6 +745,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     static public String modifiedToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -757,6 +765,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     static public String instanceShapeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -776,6 +785,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     static public String serviceProviderToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -795,6 +805,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     static public String titleToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -814,6 +825,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     static public String typeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -832,6 +844,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     static public String executionInstructionsToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -850,6 +863,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     static public String relatedChangeRequestToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -868,6 +882,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     static public String validatesRequirementToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -887,6 +902,7 @@ public class TestScript
     }
     
     
+    @Deprecated
     public String contributorToHtml()
     {
         String s = "";
@@ -912,6 +928,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     public String createdToHtml()
     {
         String s = "";
@@ -936,6 +953,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     public String creatorToHtml()
     {
         String s = "";
@@ -961,6 +979,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     public String descriptionToHtml()
     {
         String s = "";
@@ -985,6 +1004,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     public String identifierToHtml()
     {
         String s = "";
@@ -1009,6 +1029,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     public String modifiedToHtml()
     {
         String s = "";
@@ -1033,6 +1054,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     public String instanceShapeToHtml()
     {
         String s = "";
@@ -1057,6 +1079,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     public String serviceProviderToHtml()
     {
         String s = "";
@@ -1083,6 +1106,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     public String titleToHtml()
     {
         String s = "";
@@ -1107,6 +1131,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     public String typeToHtml()
     {
         String s = "";
@@ -1137,6 +1162,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     public String executionInstructionsToHtml()
     {
         String s = "";
@@ -1167,6 +1193,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     public String relatedChangeRequestToHtml()
     {
         String s = "";
@@ -1192,6 +1219,7 @@ public class TestScript
         return s;
     }
     
+    @Deprecated
     public String validatesRequirementToHtml()
     {
         String s = "";

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/IRequirement.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/IRequirement.java
@@ -141,7 +141,7 @@ public interface IRequirement
     @OslcValueType(ValueType.String)
     @OslcReadOnly(false)
     @OslcTitle("")
-    public HashSet<String> getSubject();
+    public Set<String> getSubject();
 
     @OslcName("creator")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "creator")
@@ -150,7 +150,7 @@ public interface IRequirement
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator();
+    public Set<Link> getCreator();
 
     @OslcName("contributor")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "contributor")
@@ -159,7 +159,7 @@ public interface IRequirement
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor();
+    public Set<Link> getContributor();
 
     @OslcName("created")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "created")
@@ -183,14 +183,14 @@ public interface IRequirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType();
+    public Set<Link> getType();
 
     @OslcName("serviceProvider")
     @OslcPropertyDefinition(OslcDomainConstants.OSLC_NAMSPACE + "serviceProvider")
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider();
+    public Set<URI> getServiceProvider();
 
     @OslcName("instanceShape")
     @OslcPropertyDefinition(OslcDomainConstants.OSLC_NAMSPACE + "instanceShape")
@@ -205,7 +205,7 @@ public interface IRequirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getElaboratedBy();
+    public Set<Link> getElaboratedBy();
 
     @OslcName("elaborates")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "elaborates")
@@ -213,7 +213,7 @@ public interface IRequirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getElaborates();
+    public Set<Link> getElaborates();
 
     @OslcName("specifiedBy")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "specifiedBy")
@@ -221,7 +221,7 @@ public interface IRequirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getSpecifiedBy();
+    public Set<Link> getSpecifiedBy();
 
     @OslcName("specifies")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "specifies")
@@ -229,7 +229,7 @@ public interface IRequirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getSpecifies();
+    public Set<Link> getSpecifies();
 
     @OslcName("affectedBy")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "affectedBy")
@@ -237,7 +237,7 @@ public interface IRequirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getAffectedBy();
+    public Set<Link> getAffectedBy();
 
     @OslcName("trackedBy")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "trackedBy")
@@ -245,7 +245,7 @@ public interface IRequirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getTrackedBy();
+    public Set<Link> getTrackedBy();
 
     @OslcName("implementedBy")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "implementedBy")
@@ -253,7 +253,7 @@ public interface IRequirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getImplementedBy();
+    public Set<Link> getImplementedBy();
 
     @OslcName("validatedBy")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "validatedBy")
@@ -261,7 +261,7 @@ public interface IRequirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getValidatedBy();
+    public Set<Link> getValidatedBy();
 
     @OslcName("satisfiedBy")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "satisfiedBy")
@@ -269,7 +269,7 @@ public interface IRequirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getSatisfiedBy();
+    public Set<Link> getSatisfiedBy();
 
     @OslcName("satisfies")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "satisfies")
@@ -277,7 +277,7 @@ public interface IRequirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getSatisfies();
+    public Set<Link> getSatisfies();
 
     @OslcName("decomposedBy")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "decomposedBy")
@@ -285,7 +285,7 @@ public interface IRequirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getDecomposedBy();
+    public Set<Link> getDecomposedBy();
 
     @OslcName("decomposes")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "decomposes")
@@ -293,7 +293,7 @@ public interface IRequirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getDecomposes();
+    public Set<Link> getDecomposes();
 
     @OslcName("constrainedBy")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "constrainedBy")
@@ -301,7 +301,7 @@ public interface IRequirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getConstrainedBy();
+    public Set<Link> getConstrainedBy();
 
     @OslcName("constrains")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "constrains")
@@ -309,34 +309,34 @@ public interface IRequirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getConstrains();
+    public Set<Link> getConstrains();
 
 
     public void setTitle(final String title );
     public void setDescription(final String description );
     public void setIdentifier(final String identifier );
     public void setShortTitle(final String shortTitle );
-    public void setSubject(final HashSet<String> subject );
-    public void setCreator(final HashSet<Link> creator );
-    public void setContributor(final HashSet<Link> contributor );
+    public void setSubject(final Set<String> subject );
+    public void setCreator(final Set<Link> creator );
+    public void setContributor(final Set<Link> contributor );
     public void setCreated(final Date created );
     public void setModified(final Date modified );
-    public void setType(final HashSet<Link> type );
-    public void setServiceProvider(final HashSet<URI> serviceProvider );
+    public void setType(final Set<Link> type );
+    public void setServiceProvider(final Set<URI> serviceProvider );
     public void setInstanceShape(final URI instanceShape );
-    public void setElaboratedBy(final HashSet<Link> elaboratedBy );
-    public void setElaborates(final HashSet<Link> elaborates );
-    public void setSpecifiedBy(final HashSet<Link> specifiedBy );
-    public void setSpecifies(final HashSet<Link> specifies );
-    public void setAffectedBy(final HashSet<Link> affectedBy );
-    public void setTrackedBy(final HashSet<Link> trackedBy );
-    public void setImplementedBy(final HashSet<Link> implementedBy );
-    public void setValidatedBy(final HashSet<Link> validatedBy );
-    public void setSatisfiedBy(final HashSet<Link> satisfiedBy );
-    public void setSatisfies(final HashSet<Link> satisfies );
-    public void setDecomposedBy(final HashSet<Link> decomposedBy );
-    public void setDecomposes(final HashSet<Link> decomposes );
-    public void setConstrainedBy(final HashSet<Link> constrainedBy );
-    public void setConstrains(final HashSet<Link> constrains );
+    public void setElaboratedBy(final Set<Link> elaboratedBy );
+    public void setElaborates(final Set<Link> elaborates );
+    public void setSpecifiedBy(final Set<Link> specifiedBy );
+    public void setSpecifies(final Set<Link> specifies );
+    public void setAffectedBy(final Set<Link> affectedBy );
+    public void setTrackedBy(final Set<Link> trackedBy );
+    public void setImplementedBy(final Set<Link> implementedBy );
+    public void setValidatedBy(final Set<Link> validatedBy );
+    public void setSatisfiedBy(final Set<Link> satisfiedBy );
+    public void setSatisfies(final Set<Link> satisfies );
+    public void setDecomposedBy(final Set<Link> decomposedBy );
+    public void setDecomposes(final Set<Link> decomposes );
+    public void setConstrainedBy(final Set<Link> constrainedBy );
+    public void setConstrains(final Set<Link> constrains );
 }
 

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/IRequirementCollection.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/IRequirementCollection.java
@@ -141,7 +141,7 @@ public interface IRequirementCollection
     @OslcValueType(ValueType.String)
     @OslcReadOnly(false)
     @OslcTitle("")
-    public HashSet<String> getSubject();
+    public Set<String> getSubject();
 
     @OslcName("creator")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "creator")
@@ -150,7 +150,7 @@ public interface IRequirementCollection
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator();
+    public Set<Link> getCreator();
 
     @OslcName("contributor")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "contributor")
@@ -159,7 +159,7 @@ public interface IRequirementCollection
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor();
+    public Set<Link> getContributor();
 
     @OslcName("created")
     @OslcPropertyDefinition(DctermsDomainConstants.DUBLIN_CORE_NAMSPACE + "created")
@@ -183,14 +183,14 @@ public interface IRequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType();
+    public Set<Link> getType();
 
     @OslcName("serviceProvider")
     @OslcPropertyDefinition(OslcDomainConstants.OSLC_NAMSPACE + "serviceProvider")
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider();
+    public Set<URI> getServiceProvider();
 
     @OslcName("instanceShape")
     @OslcPropertyDefinition(OslcDomainConstants.OSLC_NAMSPACE + "instanceShape")
@@ -205,7 +205,7 @@ public interface IRequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getElaboratedBy();
+    public Set<Link> getElaboratedBy();
 
     @OslcName("elaborates")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "elaborates")
@@ -213,7 +213,7 @@ public interface IRequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getElaborates();
+    public Set<Link> getElaborates();
 
     @OslcName("specifiedBy")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "specifiedBy")
@@ -221,7 +221,7 @@ public interface IRequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getSpecifiedBy();
+    public Set<Link> getSpecifiedBy();
 
     @OslcName("specifies")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "specifies")
@@ -229,7 +229,7 @@ public interface IRequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getSpecifies();
+    public Set<Link> getSpecifies();
 
     @OslcName("affectedBy")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "affectedBy")
@@ -237,7 +237,7 @@ public interface IRequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getAffectedBy();
+    public Set<Link> getAffectedBy();
 
     @OslcName("trackedBy")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "trackedBy")
@@ -245,7 +245,7 @@ public interface IRequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getTrackedBy();
+    public Set<Link> getTrackedBy();
 
     @OslcName("implementedBy")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "implementedBy")
@@ -253,7 +253,7 @@ public interface IRequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getImplementedBy();
+    public Set<Link> getImplementedBy();
 
     @OslcName("validatedBy")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "validatedBy")
@@ -261,7 +261,7 @@ public interface IRequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getValidatedBy();
+    public Set<Link> getValidatedBy();
 
     @OslcName("satisfiedBy")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "satisfiedBy")
@@ -269,7 +269,7 @@ public interface IRequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getSatisfiedBy();
+    public Set<Link> getSatisfiedBy();
 
     @OslcName("satisfies")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "satisfies")
@@ -277,7 +277,7 @@ public interface IRequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getSatisfies();
+    public Set<Link> getSatisfies();
 
     @OslcName("decomposedBy")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "decomposedBy")
@@ -285,7 +285,7 @@ public interface IRequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getDecomposedBy();
+    public Set<Link> getDecomposedBy();
 
     @OslcName("decomposes")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "decomposes")
@@ -293,7 +293,7 @@ public interface IRequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getDecomposes();
+    public Set<Link> getDecomposes();
 
     @OslcName("constrainedBy")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "constrainedBy")
@@ -301,7 +301,7 @@ public interface IRequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getConstrainedBy();
+    public Set<Link> getConstrainedBy();
 
     @OslcName("constrains")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "constrains")
@@ -309,34 +309,34 @@ public interface IRequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getConstrains();
+    public Set<Link> getConstrains();
 
 
     public void setTitle(final String title );
     public void setDescription(final String description );
     public void setIdentifier(final String identifier );
     public void setShortTitle(final String shortTitle );
-    public void setSubject(final HashSet<String> subject );
-    public void setCreator(final HashSet<Link> creator );
-    public void setContributor(final HashSet<Link> contributor );
+    public void setSubject(final Set<String> subject );
+    public void setCreator(final Set<Link> creator );
+    public void setContributor(final Set<Link> contributor );
     public void setCreated(final Date created );
     public void setModified(final Date modified );
-    public void setType(final HashSet<Link> type );
-    public void setServiceProvider(final HashSet<URI> serviceProvider );
+    public void setType(final Set<Link> type );
+    public void setServiceProvider(final Set<URI> serviceProvider );
     public void setInstanceShape(final URI instanceShape );
-    public void setElaboratedBy(final HashSet<Link> elaboratedBy );
-    public void setElaborates(final HashSet<Link> elaborates );
-    public void setSpecifiedBy(final HashSet<Link> specifiedBy );
-    public void setSpecifies(final HashSet<Link> specifies );
-    public void setAffectedBy(final HashSet<Link> affectedBy );
-    public void setTrackedBy(final HashSet<Link> trackedBy );
-    public void setImplementedBy(final HashSet<Link> implementedBy );
-    public void setValidatedBy(final HashSet<Link> validatedBy );
-    public void setSatisfiedBy(final HashSet<Link> satisfiedBy );
-    public void setSatisfies(final HashSet<Link> satisfies );
-    public void setDecomposedBy(final HashSet<Link> decomposedBy );
-    public void setDecomposes(final HashSet<Link> decomposes );
-    public void setConstrainedBy(final HashSet<Link> constrainedBy );
-    public void setConstrains(final HashSet<Link> constrains );
+    public void setElaboratedBy(final Set<Link> elaboratedBy );
+    public void setElaborates(final Set<Link> elaborates );
+    public void setSpecifiedBy(final Set<Link> specifiedBy );
+    public void setSpecifies(final Set<Link> specifies );
+    public void setAffectedBy(final Set<Link> affectedBy );
+    public void setTrackedBy(final Set<Link> trackedBy );
+    public void setImplementedBy(final Set<Link> implementedBy );
+    public void setValidatedBy(final Set<Link> validatedBy );
+    public void setSatisfiedBy(final Set<Link> satisfiedBy );
+    public void setSatisfies(final Set<Link> satisfies );
+    public void setDecomposedBy(final Set<Link> decomposedBy );
+    public void setDecomposes(final Set<Link> decomposes );
+    public void setConstrainedBy(final Set<Link> constrainedBy );
+    public void setConstrains(final Set<Link> constrains );
 }
 

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/Requirement.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/Requirement.java
@@ -110,13 +110,13 @@ public class Requirement
     private String shortTitle;
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private HashSet<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<String>();
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private HashSet<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<Link>();
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private HashSet<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<Link>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
@@ -125,55 +125,55 @@ public class Requirement
     private Date modified;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private HashSet<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<Link>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private HashSet<URI> serviceProvider = new HashSet<URI>();
+    private Set<URI> serviceProvider = new HashSet<URI>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
     private URI instanceShape;
     // Start of user code attributeAnnotation:elaboratedBy
     // End of user code
-    private HashSet<Link> elaboratedBy = new HashSet<Link>();
+    private Set<Link> elaboratedBy = new HashSet<Link>();
     // Start of user code attributeAnnotation:elaborates
     // End of user code
-    private HashSet<Link> elaborates = new HashSet<Link>();
+    private Set<Link> elaborates = new HashSet<Link>();
     // Start of user code attributeAnnotation:specifiedBy
     // End of user code
-    private HashSet<Link> specifiedBy = new HashSet<Link>();
+    private Set<Link> specifiedBy = new HashSet<Link>();
     // Start of user code attributeAnnotation:specifies
     // End of user code
-    private HashSet<Link> specifies = new HashSet<Link>();
+    private Set<Link> specifies = new HashSet<Link>();
     // Start of user code attributeAnnotation:affectedBy
     // End of user code
-    private HashSet<Link> affectedBy = new HashSet<Link>();
+    private Set<Link> affectedBy = new HashSet<Link>();
     // Start of user code attributeAnnotation:trackedBy
     // End of user code
-    private HashSet<Link> trackedBy = new HashSet<Link>();
+    private Set<Link> trackedBy = new HashSet<Link>();
     // Start of user code attributeAnnotation:implementedBy
     // End of user code
-    private HashSet<Link> implementedBy = new HashSet<Link>();
+    private Set<Link> implementedBy = new HashSet<Link>();
     // Start of user code attributeAnnotation:validatedBy
     // End of user code
-    private HashSet<Link> validatedBy = new HashSet<Link>();
+    private Set<Link> validatedBy = new HashSet<Link>();
     // Start of user code attributeAnnotation:satisfiedBy
     // End of user code
-    private HashSet<Link> satisfiedBy = new HashSet<Link>();
+    private Set<Link> satisfiedBy = new HashSet<Link>();
     // Start of user code attributeAnnotation:satisfies
     // End of user code
-    private HashSet<Link> satisfies = new HashSet<Link>();
+    private Set<Link> satisfies = new HashSet<Link>();
     // Start of user code attributeAnnotation:decomposedBy
     // End of user code
-    private HashSet<Link> decomposedBy = new HashSet<Link>();
+    private Set<Link> decomposedBy = new HashSet<Link>();
     // Start of user code attributeAnnotation:decomposes
     // End of user code
-    private HashSet<Link> decomposes = new HashSet<Link>();
+    private Set<Link> decomposes = new HashSet<Link>();
     // Start of user code attributeAnnotation:constrainedBy
     // End of user code
-    private HashSet<Link> constrainedBy = new HashSet<Link>();
+    private Set<Link> constrainedBy = new HashSet<Link>();
     // Start of user code attributeAnnotation:constrains
     // End of user code
-    private HashSet<Link> constrains = new HashSet<Link>();
+    private Set<Link> constrains = new HashSet<Link>();
     
     // Start of user code classAttributes
     // End of user code
@@ -232,11 +232,13 @@ public class Requirement
         return result;
     }
     
+    @Deprecated
     public String toHtml()
     {
         return toHtml(false);
     }
     
+    @Deprecated
     public String toHtml(boolean asLocalResource)
     {
         String result = "";
@@ -423,7 +425,7 @@ public class Requirement
     @OslcValueType(ValueType.String)
     @OslcReadOnly(false)
     @OslcTitle("")
-    public HashSet<String> getSubject()
+    public Set<String> getSubject()
     {
         // Start of user code getterInit:subject
         // End of user code
@@ -439,7 +441,7 @@ public class Requirement
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator()
+    public Set<Link> getCreator()
     {
         // Start of user code getterInit:creator
         // End of user code
@@ -455,7 +457,7 @@ public class Requirement
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor()
+    public Set<Link> getContributor()
     {
         // Start of user code getterInit:contributor
         // End of user code
@@ -500,7 +502,7 @@ public class Requirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType()
+    public Set<Link> getType()
     {
         // Start of user code getterInit:type
         // End of user code
@@ -514,7 +516,7 @@ public class Requirement
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider()
+    public Set<URI> getServiceProvider()
     {
         // Start of user code getterInit:serviceProvider
         // End of user code
@@ -543,7 +545,7 @@ public class Requirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getElaboratedBy()
+    public Set<Link> getElaboratedBy()
     {
         // Start of user code getterInit:elaboratedBy
         // End of user code
@@ -558,7 +560,7 @@ public class Requirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getElaborates()
+    public Set<Link> getElaborates()
     {
         // Start of user code getterInit:elaborates
         // End of user code
@@ -573,7 +575,7 @@ public class Requirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getSpecifiedBy()
+    public Set<Link> getSpecifiedBy()
     {
         // Start of user code getterInit:specifiedBy
         // End of user code
@@ -588,7 +590,7 @@ public class Requirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getSpecifies()
+    public Set<Link> getSpecifies()
     {
         // Start of user code getterInit:specifies
         // End of user code
@@ -603,7 +605,7 @@ public class Requirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getAffectedBy()
+    public Set<Link> getAffectedBy()
     {
         // Start of user code getterInit:affectedBy
         // End of user code
@@ -618,7 +620,7 @@ public class Requirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getTrackedBy()
+    public Set<Link> getTrackedBy()
     {
         // Start of user code getterInit:trackedBy
         // End of user code
@@ -633,7 +635,7 @@ public class Requirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getImplementedBy()
+    public Set<Link> getImplementedBy()
     {
         // Start of user code getterInit:implementedBy
         // End of user code
@@ -648,7 +650,7 @@ public class Requirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getValidatedBy()
+    public Set<Link> getValidatedBy()
     {
         // Start of user code getterInit:validatedBy
         // End of user code
@@ -663,7 +665,7 @@ public class Requirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getSatisfiedBy()
+    public Set<Link> getSatisfiedBy()
     {
         // Start of user code getterInit:satisfiedBy
         // End of user code
@@ -678,7 +680,7 @@ public class Requirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getSatisfies()
+    public Set<Link> getSatisfies()
     {
         // Start of user code getterInit:satisfies
         // End of user code
@@ -693,7 +695,7 @@ public class Requirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getDecomposedBy()
+    public Set<Link> getDecomposedBy()
     {
         // Start of user code getterInit:decomposedBy
         // End of user code
@@ -708,7 +710,7 @@ public class Requirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getDecomposes()
+    public Set<Link> getDecomposes()
     {
         // Start of user code getterInit:decomposes
         // End of user code
@@ -723,7 +725,7 @@ public class Requirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getConstrainedBy()
+    public Set<Link> getConstrainedBy()
     {
         // Start of user code getterInit:constrainedBy
         // End of user code
@@ -738,7 +740,7 @@ public class Requirement
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getConstrains()
+    public Set<Link> getConstrains()
     {
         // Start of user code getterInit:constrains
         // End of user code
@@ -796,7 +798,7 @@ public class Requirement
     
     // Start of user code setterAnnotation:subject
     // End of user code
-    public void setSubject(final HashSet<String> subject )
+    public void setSubject(final Set<String> subject )
     {
         // Start of user code setterInit:subject
         // End of user code
@@ -812,7 +814,7 @@ public class Requirement
     
     // Start of user code setterAnnotation:creator
     // End of user code
-    public void setCreator(final HashSet<Link> creator )
+    public void setCreator(final Set<Link> creator )
     {
         // Start of user code setterInit:creator
         // End of user code
@@ -828,7 +830,7 @@ public class Requirement
     
     // Start of user code setterAnnotation:contributor
     // End of user code
-    public void setContributor(final HashSet<Link> contributor )
+    public void setContributor(final Set<Link> contributor )
     {
         // Start of user code setterInit:contributor
         // End of user code
@@ -868,7 +870,7 @@ public class Requirement
     
     // Start of user code setterAnnotation:type
     // End of user code
-    public void setType(final HashSet<Link> type )
+    public void setType(final Set<Link> type )
     {
         // Start of user code setterInit:type
         // End of user code
@@ -884,7 +886,7 @@ public class Requirement
     
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
-    public void setServiceProvider(final HashSet<URI> serviceProvider )
+    public void setServiceProvider(final Set<URI> serviceProvider )
     {
         // Start of user code setterInit:serviceProvider
         // End of user code
@@ -912,7 +914,7 @@ public class Requirement
     
     // Start of user code setterAnnotation:elaboratedBy
     // End of user code
-    public void setElaboratedBy(final HashSet<Link> elaboratedBy )
+    public void setElaboratedBy(final Set<Link> elaboratedBy )
     {
         // Start of user code setterInit:elaboratedBy
         // End of user code
@@ -928,7 +930,7 @@ public class Requirement
     
     // Start of user code setterAnnotation:elaborates
     // End of user code
-    public void setElaborates(final HashSet<Link> elaborates )
+    public void setElaborates(final Set<Link> elaborates )
     {
         // Start of user code setterInit:elaborates
         // End of user code
@@ -944,7 +946,7 @@ public class Requirement
     
     // Start of user code setterAnnotation:specifiedBy
     // End of user code
-    public void setSpecifiedBy(final HashSet<Link> specifiedBy )
+    public void setSpecifiedBy(final Set<Link> specifiedBy )
     {
         // Start of user code setterInit:specifiedBy
         // End of user code
@@ -960,7 +962,7 @@ public class Requirement
     
     // Start of user code setterAnnotation:specifies
     // End of user code
-    public void setSpecifies(final HashSet<Link> specifies )
+    public void setSpecifies(final Set<Link> specifies )
     {
         // Start of user code setterInit:specifies
         // End of user code
@@ -976,7 +978,7 @@ public class Requirement
     
     // Start of user code setterAnnotation:affectedBy
     // End of user code
-    public void setAffectedBy(final HashSet<Link> affectedBy )
+    public void setAffectedBy(final Set<Link> affectedBy )
     {
         // Start of user code setterInit:affectedBy
         // End of user code
@@ -992,7 +994,7 @@ public class Requirement
     
     // Start of user code setterAnnotation:trackedBy
     // End of user code
-    public void setTrackedBy(final HashSet<Link> trackedBy )
+    public void setTrackedBy(final Set<Link> trackedBy )
     {
         // Start of user code setterInit:trackedBy
         // End of user code
@@ -1008,7 +1010,7 @@ public class Requirement
     
     // Start of user code setterAnnotation:implementedBy
     // End of user code
-    public void setImplementedBy(final HashSet<Link> implementedBy )
+    public void setImplementedBy(final Set<Link> implementedBy )
     {
         // Start of user code setterInit:implementedBy
         // End of user code
@@ -1024,7 +1026,7 @@ public class Requirement
     
     // Start of user code setterAnnotation:validatedBy
     // End of user code
-    public void setValidatedBy(final HashSet<Link> validatedBy )
+    public void setValidatedBy(final Set<Link> validatedBy )
     {
         // Start of user code setterInit:validatedBy
         // End of user code
@@ -1040,7 +1042,7 @@ public class Requirement
     
     // Start of user code setterAnnotation:satisfiedBy
     // End of user code
-    public void setSatisfiedBy(final HashSet<Link> satisfiedBy )
+    public void setSatisfiedBy(final Set<Link> satisfiedBy )
     {
         // Start of user code setterInit:satisfiedBy
         // End of user code
@@ -1056,7 +1058,7 @@ public class Requirement
     
     // Start of user code setterAnnotation:satisfies
     // End of user code
-    public void setSatisfies(final HashSet<Link> satisfies )
+    public void setSatisfies(final Set<Link> satisfies )
     {
         // Start of user code setterInit:satisfies
         // End of user code
@@ -1072,7 +1074,7 @@ public class Requirement
     
     // Start of user code setterAnnotation:decomposedBy
     // End of user code
-    public void setDecomposedBy(final HashSet<Link> decomposedBy )
+    public void setDecomposedBy(final Set<Link> decomposedBy )
     {
         // Start of user code setterInit:decomposedBy
         // End of user code
@@ -1088,7 +1090,7 @@ public class Requirement
     
     // Start of user code setterAnnotation:decomposes
     // End of user code
-    public void setDecomposes(final HashSet<Link> decomposes )
+    public void setDecomposes(final Set<Link> decomposes )
     {
         // Start of user code setterInit:decomposes
         // End of user code
@@ -1104,7 +1106,7 @@ public class Requirement
     
     // Start of user code setterAnnotation:constrainedBy
     // End of user code
-    public void setConstrainedBy(final HashSet<Link> constrainedBy )
+    public void setConstrainedBy(final Set<Link> constrainedBy )
     {
         // Start of user code setterInit:constrainedBy
         // End of user code
@@ -1120,7 +1122,7 @@ public class Requirement
     
     // Start of user code setterAnnotation:constrains
     // End of user code
-    public void setConstrains(final HashSet<Link> constrains )
+    public void setConstrains(final Set<Link> constrains )
     {
         // Start of user code setterInit:constrains
         // End of user code
@@ -1135,6 +1137,7 @@ public class Requirement
     }
     
     
+    @Deprecated
     static public String titleToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1154,6 +1157,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String descriptionToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1173,6 +1177,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String identifierToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1192,6 +1197,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String shortTitleToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1211,6 +1217,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String subjectToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1230,6 +1237,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String creatorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1248,6 +1256,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String contributorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1266,6 +1275,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String createdToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1285,6 +1295,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String modifiedToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1304,6 +1315,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String typeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1322,6 +1334,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String serviceProviderToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1341,6 +1354,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String instanceShapeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1360,6 +1374,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String elaboratedByToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1378,6 +1393,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String elaboratesToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1396,6 +1412,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String specifiedByToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1414,6 +1431,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String specifiesToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1432,6 +1450,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String affectedByToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1450,6 +1469,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String trackedByToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1468,6 +1488,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String implementedByToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1486,6 +1507,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String validatedByToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1504,6 +1526,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String satisfiedByToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1522,6 +1545,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String satisfiesToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1540,6 +1564,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String decomposedByToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1558,6 +1583,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String decomposesToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1576,6 +1602,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String constrainedByToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1594,6 +1621,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     static public String constrainsToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1613,6 +1641,7 @@ public class Requirement
     }
     
     
+    @Deprecated
     public String titleToHtml()
     {
         String s = "";
@@ -1637,6 +1666,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String descriptionToHtml()
     {
         String s = "";
@@ -1661,6 +1691,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String identifierToHtml()
     {
         String s = "";
@@ -1685,6 +1716,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String shortTitleToHtml()
     {
         String s = "";
@@ -1709,6 +1741,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String subjectToHtml()
     {
         String s = "";
@@ -1735,6 +1768,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String creatorToHtml()
     {
         String s = "";
@@ -1760,6 +1794,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String contributorToHtml()
     {
         String s = "";
@@ -1785,6 +1820,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String createdToHtml()
     {
         String s = "";
@@ -1809,6 +1845,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String modifiedToHtml()
     {
         String s = "";
@@ -1833,6 +1870,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String typeToHtml()
     {
         String s = "";
@@ -1863,6 +1901,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String serviceProviderToHtml()
     {
         String s = "";
@@ -1889,6 +1928,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String instanceShapeToHtml()
     {
         String s = "";
@@ -1913,6 +1953,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String elaboratedByToHtml()
     {
         String s = "";
@@ -1943,6 +1984,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String elaboratesToHtml()
     {
         String s = "";
@@ -1973,6 +2015,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String specifiedByToHtml()
     {
         String s = "";
@@ -2003,6 +2046,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String specifiesToHtml()
     {
         String s = "";
@@ -2033,6 +2077,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String affectedByToHtml()
     {
         String s = "";
@@ -2063,6 +2108,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String trackedByToHtml()
     {
         String s = "";
@@ -2093,6 +2139,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String implementedByToHtml()
     {
         String s = "";
@@ -2123,6 +2170,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String validatedByToHtml()
     {
         String s = "";
@@ -2153,6 +2201,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String satisfiedByToHtml()
     {
         String s = "";
@@ -2183,6 +2232,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String satisfiesToHtml()
     {
         String s = "";
@@ -2213,6 +2263,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String decomposedByToHtml()
     {
         String s = "";
@@ -2243,6 +2294,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String decomposesToHtml()
     {
         String s = "";
@@ -2273,6 +2325,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String constrainedByToHtml()
     {
         String s = "";
@@ -2303,6 +2356,7 @@ public class Requirement
         return s;
     }
     
+    @Deprecated
     public String constrainsToHtml()
     {
         String s = "";

--- a/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/RequirementCollection.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/RequirementCollection.java
@@ -110,13 +110,13 @@ public class RequirementCollection
     private String shortTitle;
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private HashSet<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<String>();
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private HashSet<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<Link>();
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private HashSet<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<Link>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
@@ -125,55 +125,55 @@ public class RequirementCollection
     private Date modified;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private HashSet<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<Link>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private HashSet<URI> serviceProvider = new HashSet<URI>();
+    private Set<URI> serviceProvider = new HashSet<URI>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
     private URI instanceShape;
     // Start of user code attributeAnnotation:elaboratedBy
     // End of user code
-    private HashSet<Link> elaboratedBy = new HashSet<Link>();
+    private Set<Link> elaboratedBy = new HashSet<Link>();
     // Start of user code attributeAnnotation:elaborates
     // End of user code
-    private HashSet<Link> elaborates = new HashSet<Link>();
+    private Set<Link> elaborates = new HashSet<Link>();
     // Start of user code attributeAnnotation:specifiedBy
     // End of user code
-    private HashSet<Link> specifiedBy = new HashSet<Link>();
+    private Set<Link> specifiedBy = new HashSet<Link>();
     // Start of user code attributeAnnotation:specifies
     // End of user code
-    private HashSet<Link> specifies = new HashSet<Link>();
+    private Set<Link> specifies = new HashSet<Link>();
     // Start of user code attributeAnnotation:affectedBy
     // End of user code
-    private HashSet<Link> affectedBy = new HashSet<Link>();
+    private Set<Link> affectedBy = new HashSet<Link>();
     // Start of user code attributeAnnotation:trackedBy
     // End of user code
-    private HashSet<Link> trackedBy = new HashSet<Link>();
+    private Set<Link> trackedBy = new HashSet<Link>();
     // Start of user code attributeAnnotation:implementedBy
     // End of user code
-    private HashSet<Link> implementedBy = new HashSet<Link>();
+    private Set<Link> implementedBy = new HashSet<Link>();
     // Start of user code attributeAnnotation:validatedBy
     // End of user code
-    private HashSet<Link> validatedBy = new HashSet<Link>();
+    private Set<Link> validatedBy = new HashSet<Link>();
     // Start of user code attributeAnnotation:satisfiedBy
     // End of user code
-    private HashSet<Link> satisfiedBy = new HashSet<Link>();
+    private Set<Link> satisfiedBy = new HashSet<Link>();
     // Start of user code attributeAnnotation:satisfies
     // End of user code
-    private HashSet<Link> satisfies = new HashSet<Link>();
+    private Set<Link> satisfies = new HashSet<Link>();
     // Start of user code attributeAnnotation:decomposedBy
     // End of user code
-    private HashSet<Link> decomposedBy = new HashSet<Link>();
+    private Set<Link> decomposedBy = new HashSet<Link>();
     // Start of user code attributeAnnotation:decomposes
     // End of user code
-    private HashSet<Link> decomposes = new HashSet<Link>();
+    private Set<Link> decomposes = new HashSet<Link>();
     // Start of user code attributeAnnotation:constrainedBy
     // End of user code
-    private HashSet<Link> constrainedBy = new HashSet<Link>();
+    private Set<Link> constrainedBy = new HashSet<Link>();
     // Start of user code attributeAnnotation:constrains
     // End of user code
-    private HashSet<Link> constrains = new HashSet<Link>();
+    private Set<Link> constrains = new HashSet<Link>();
     
     // Start of user code classAttributes
     // End of user code
@@ -232,11 +232,13 @@ public class RequirementCollection
         return result;
     }
     
+    @Deprecated
     public String toHtml()
     {
         return toHtml(false);
     }
     
+    @Deprecated
     public String toHtml(boolean asLocalResource)
     {
         String result = "";
@@ -423,7 +425,7 @@ public class RequirementCollection
     @OslcValueType(ValueType.String)
     @OslcReadOnly(false)
     @OslcTitle("")
-    public HashSet<String> getSubject()
+    public Set<String> getSubject()
     {
         // Start of user code getterInit:subject
         // End of user code
@@ -439,7 +441,7 @@ public class RequirementCollection
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getCreator()
+    public Set<Link> getCreator()
     {
         // Start of user code getterInit:creator
         // End of user code
@@ -455,7 +457,7 @@ public class RequirementCollection
     @OslcValueType(ValueType.Resource)
     @OslcRange({FoafDomainConstants.PERSON_TYPE})
     @OslcReadOnly(false)
-    public HashSet<Link> getContributor()
+    public Set<Link> getContributor()
     {
         // Start of user code getterInit:contributor
         // End of user code
@@ -500,7 +502,7 @@ public class RequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getType()
+    public Set<Link> getType()
     {
         // Start of user code getterInit:type
         // End of user code
@@ -514,7 +516,7 @@ public class RequirementCollection
     @OslcDescription("A link to the resource's OSLC Service Provider. There may be cases when the subject resource is available from a service provider that implements multiple domain specifications, which could result in multiple values for this property.")
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcReadOnly(false)
-    public HashSet<URI> getServiceProvider()
+    public Set<URI> getServiceProvider()
     {
         // Start of user code getterInit:serviceProvider
         // End of user code
@@ -543,7 +545,7 @@ public class RequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getElaboratedBy()
+    public Set<Link> getElaboratedBy()
     {
         // Start of user code getterInit:elaboratedBy
         // End of user code
@@ -558,7 +560,7 @@ public class RequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getElaborates()
+    public Set<Link> getElaborates()
     {
         // Start of user code getterInit:elaborates
         // End of user code
@@ -573,7 +575,7 @@ public class RequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getSpecifiedBy()
+    public Set<Link> getSpecifiedBy()
     {
         // Start of user code getterInit:specifiedBy
         // End of user code
@@ -588,7 +590,7 @@ public class RequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getSpecifies()
+    public Set<Link> getSpecifies()
     {
         // Start of user code getterInit:specifies
         // End of user code
@@ -603,7 +605,7 @@ public class RequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getAffectedBy()
+    public Set<Link> getAffectedBy()
     {
         // Start of user code getterInit:affectedBy
         // End of user code
@@ -618,7 +620,7 @@ public class RequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getTrackedBy()
+    public Set<Link> getTrackedBy()
     {
         // Start of user code getterInit:trackedBy
         // End of user code
@@ -633,7 +635,7 @@ public class RequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getImplementedBy()
+    public Set<Link> getImplementedBy()
     {
         // Start of user code getterInit:implementedBy
         // End of user code
@@ -648,7 +650,7 @@ public class RequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getValidatedBy()
+    public Set<Link> getValidatedBy()
     {
         // Start of user code getterInit:validatedBy
         // End of user code
@@ -663,7 +665,7 @@ public class RequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getSatisfiedBy()
+    public Set<Link> getSatisfiedBy()
     {
         // Start of user code getterInit:satisfiedBy
         // End of user code
@@ -678,7 +680,7 @@ public class RequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getSatisfies()
+    public Set<Link> getSatisfies()
     {
         // Start of user code getterInit:satisfies
         // End of user code
@@ -693,7 +695,7 @@ public class RequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getDecomposedBy()
+    public Set<Link> getDecomposedBy()
     {
         // Start of user code getterInit:decomposedBy
         // End of user code
@@ -708,7 +710,7 @@ public class RequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getDecomposes()
+    public Set<Link> getDecomposes()
     {
         // Start of user code getterInit:decomposes
         // End of user code
@@ -723,7 +725,7 @@ public class RequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getConstrainedBy()
+    public Set<Link> getConstrainedBy()
     {
         // Start of user code getterInit:constrainedBy
         // End of user code
@@ -738,7 +740,7 @@ public class RequirementCollection
     @OslcOccurs(Occurs.ZeroOrMany)
     @OslcValueType(ValueType.Resource)
     @OslcReadOnly(false)
-    public HashSet<Link> getConstrains()
+    public Set<Link> getConstrains()
     {
         // Start of user code getterInit:constrains
         // End of user code
@@ -796,7 +798,7 @@ public class RequirementCollection
     
     // Start of user code setterAnnotation:subject
     // End of user code
-    public void setSubject(final HashSet<String> subject )
+    public void setSubject(final Set<String> subject )
     {
         // Start of user code setterInit:subject
         // End of user code
@@ -812,7 +814,7 @@ public class RequirementCollection
     
     // Start of user code setterAnnotation:creator
     // End of user code
-    public void setCreator(final HashSet<Link> creator )
+    public void setCreator(final Set<Link> creator )
     {
         // Start of user code setterInit:creator
         // End of user code
@@ -828,7 +830,7 @@ public class RequirementCollection
     
     // Start of user code setterAnnotation:contributor
     // End of user code
-    public void setContributor(final HashSet<Link> contributor )
+    public void setContributor(final Set<Link> contributor )
     {
         // Start of user code setterInit:contributor
         // End of user code
@@ -868,7 +870,7 @@ public class RequirementCollection
     
     // Start of user code setterAnnotation:type
     // End of user code
-    public void setType(final HashSet<Link> type )
+    public void setType(final Set<Link> type )
     {
         // Start of user code setterInit:type
         // End of user code
@@ -884,7 +886,7 @@ public class RequirementCollection
     
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
-    public void setServiceProvider(final HashSet<URI> serviceProvider )
+    public void setServiceProvider(final Set<URI> serviceProvider )
     {
         // Start of user code setterInit:serviceProvider
         // End of user code
@@ -912,7 +914,7 @@ public class RequirementCollection
     
     // Start of user code setterAnnotation:elaboratedBy
     // End of user code
-    public void setElaboratedBy(final HashSet<Link> elaboratedBy )
+    public void setElaboratedBy(final Set<Link> elaboratedBy )
     {
         // Start of user code setterInit:elaboratedBy
         // End of user code
@@ -928,7 +930,7 @@ public class RequirementCollection
     
     // Start of user code setterAnnotation:elaborates
     // End of user code
-    public void setElaborates(final HashSet<Link> elaborates )
+    public void setElaborates(final Set<Link> elaborates )
     {
         // Start of user code setterInit:elaborates
         // End of user code
@@ -944,7 +946,7 @@ public class RequirementCollection
     
     // Start of user code setterAnnotation:specifiedBy
     // End of user code
-    public void setSpecifiedBy(final HashSet<Link> specifiedBy )
+    public void setSpecifiedBy(final Set<Link> specifiedBy )
     {
         // Start of user code setterInit:specifiedBy
         // End of user code
@@ -960,7 +962,7 @@ public class RequirementCollection
     
     // Start of user code setterAnnotation:specifies
     // End of user code
-    public void setSpecifies(final HashSet<Link> specifies )
+    public void setSpecifies(final Set<Link> specifies )
     {
         // Start of user code setterInit:specifies
         // End of user code
@@ -976,7 +978,7 @@ public class RequirementCollection
     
     // Start of user code setterAnnotation:affectedBy
     // End of user code
-    public void setAffectedBy(final HashSet<Link> affectedBy )
+    public void setAffectedBy(final Set<Link> affectedBy )
     {
         // Start of user code setterInit:affectedBy
         // End of user code
@@ -992,7 +994,7 @@ public class RequirementCollection
     
     // Start of user code setterAnnotation:trackedBy
     // End of user code
-    public void setTrackedBy(final HashSet<Link> trackedBy )
+    public void setTrackedBy(final Set<Link> trackedBy )
     {
         // Start of user code setterInit:trackedBy
         // End of user code
@@ -1008,7 +1010,7 @@ public class RequirementCollection
     
     // Start of user code setterAnnotation:implementedBy
     // End of user code
-    public void setImplementedBy(final HashSet<Link> implementedBy )
+    public void setImplementedBy(final Set<Link> implementedBy )
     {
         // Start of user code setterInit:implementedBy
         // End of user code
@@ -1024,7 +1026,7 @@ public class RequirementCollection
     
     // Start of user code setterAnnotation:validatedBy
     // End of user code
-    public void setValidatedBy(final HashSet<Link> validatedBy )
+    public void setValidatedBy(final Set<Link> validatedBy )
     {
         // Start of user code setterInit:validatedBy
         // End of user code
@@ -1040,7 +1042,7 @@ public class RequirementCollection
     
     // Start of user code setterAnnotation:satisfiedBy
     // End of user code
-    public void setSatisfiedBy(final HashSet<Link> satisfiedBy )
+    public void setSatisfiedBy(final Set<Link> satisfiedBy )
     {
         // Start of user code setterInit:satisfiedBy
         // End of user code
@@ -1056,7 +1058,7 @@ public class RequirementCollection
     
     // Start of user code setterAnnotation:satisfies
     // End of user code
-    public void setSatisfies(final HashSet<Link> satisfies )
+    public void setSatisfies(final Set<Link> satisfies )
     {
         // Start of user code setterInit:satisfies
         // End of user code
@@ -1072,7 +1074,7 @@ public class RequirementCollection
     
     // Start of user code setterAnnotation:decomposedBy
     // End of user code
-    public void setDecomposedBy(final HashSet<Link> decomposedBy )
+    public void setDecomposedBy(final Set<Link> decomposedBy )
     {
         // Start of user code setterInit:decomposedBy
         // End of user code
@@ -1088,7 +1090,7 @@ public class RequirementCollection
     
     // Start of user code setterAnnotation:decomposes
     // End of user code
-    public void setDecomposes(final HashSet<Link> decomposes )
+    public void setDecomposes(final Set<Link> decomposes )
     {
         // Start of user code setterInit:decomposes
         // End of user code
@@ -1104,7 +1106,7 @@ public class RequirementCollection
     
     // Start of user code setterAnnotation:constrainedBy
     // End of user code
-    public void setConstrainedBy(final HashSet<Link> constrainedBy )
+    public void setConstrainedBy(final Set<Link> constrainedBy )
     {
         // Start of user code setterInit:constrainedBy
         // End of user code
@@ -1120,7 +1122,7 @@ public class RequirementCollection
     
     // Start of user code setterAnnotation:constrains
     // End of user code
-    public void setConstrains(final HashSet<Link> constrains )
+    public void setConstrains(final Set<Link> constrains )
     {
         // Start of user code setterInit:constrains
         // End of user code
@@ -1135,6 +1137,7 @@ public class RequirementCollection
     }
     
     
+    @Deprecated
     static public String titleToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1154,6 +1157,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String descriptionToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1173,6 +1177,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String identifierToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1192,6 +1197,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String shortTitleToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1211,6 +1217,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String subjectToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1230,6 +1237,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String creatorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1248,6 +1256,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String contributorToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1266,6 +1275,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String createdToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1285,6 +1295,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String modifiedToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1304,6 +1315,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String typeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1322,6 +1334,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String serviceProviderToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1341,6 +1354,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String instanceShapeToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1360,6 +1374,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String elaboratedByToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1378,6 +1393,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String elaboratesToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1396,6 +1412,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String specifiedByToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1414,6 +1431,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String specifiesToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1432,6 +1450,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String affectedByToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1450,6 +1469,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String trackedByToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1468,6 +1488,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String implementedByToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1486,6 +1507,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String validatedByToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1504,6 +1526,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String satisfiedByToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1522,6 +1545,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String satisfiesToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1540,6 +1564,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String decomposedByToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1558,6 +1583,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String decomposesToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1576,6 +1602,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String constrainedByToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1594,6 +1621,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     static public String constrainsToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -1613,6 +1641,7 @@ public class RequirementCollection
     }
     
     
+    @Deprecated
     public String titleToHtml()
     {
         String s = "";
@@ -1637,6 +1666,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String descriptionToHtml()
     {
         String s = "";
@@ -1661,6 +1691,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String identifierToHtml()
     {
         String s = "";
@@ -1685,6 +1716,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String shortTitleToHtml()
     {
         String s = "";
@@ -1709,6 +1741,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String subjectToHtml()
     {
         String s = "";
@@ -1735,6 +1768,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String creatorToHtml()
     {
         String s = "";
@@ -1760,6 +1794,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String contributorToHtml()
     {
         String s = "";
@@ -1785,6 +1820,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String createdToHtml()
     {
         String s = "";
@@ -1809,6 +1845,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String modifiedToHtml()
     {
         String s = "";
@@ -1833,6 +1870,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String typeToHtml()
     {
         String s = "";
@@ -1863,6 +1901,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String serviceProviderToHtml()
     {
         String s = "";
@@ -1889,6 +1928,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String instanceShapeToHtml()
     {
         String s = "";
@@ -1913,6 +1953,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String elaboratedByToHtml()
     {
         String s = "";
@@ -1943,6 +1984,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String elaboratesToHtml()
     {
         String s = "";
@@ -1973,6 +2015,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String specifiedByToHtml()
     {
         String s = "";
@@ -2003,6 +2046,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String specifiesToHtml()
     {
         String s = "";
@@ -2033,6 +2077,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String affectedByToHtml()
     {
         String s = "";
@@ -2063,6 +2108,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String trackedByToHtml()
     {
         String s = "";
@@ -2093,6 +2139,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String implementedByToHtml()
     {
         String s = "";
@@ -2123,6 +2170,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String validatedByToHtml()
     {
         String s = "";
@@ -2153,6 +2201,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String satisfiedByToHtml()
     {
         String s = "";
@@ -2183,6 +2232,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String satisfiesToHtml()
     {
         String s = "";
@@ -2213,6 +2263,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String decomposedByToHtml()
     {
         String s = "";
@@ -2243,6 +2294,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String decomposesToHtml()
     {
         String s = "";
@@ -2273,6 +2325,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String constrainedByToHtml()
     {
         String s = "";
@@ -2303,6 +2356,7 @@ public class RequirementCollection
         return s;
     }
     
+    @Deprecated
     public String constrainsToHtml()
     {
         String s = "";


### PR DESCRIPTION
replacing HashSet attributes with Set.
No longer initializing attributes of type Link. Only
zeroOrMore/oneOrMore attributes are initialized as "new HashSet()"
Marking all toHtml methods as deprecated, to be removed in near future.
