### PR TITLE
Move DS classes from Lyo Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.lost
+
+target/
+
+.settings/
+
+.idea/
+*.iml

--- a/oslc-domains/.gitignore
+++ b/oslc-domains/.gitignore
@@ -1,3 +1,0 @@
-*.lost
-/target/
-/.settings/

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/ArchitectureConstants.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/ArchitectureConstants.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2013 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *     Michael Fiedler        - initial implementation
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+
+public interface ArchitectureConstants
+{
+    public static final String ARCHITECTURE_DOMAIN        = "http://open-services.net/ns/am#";
+    public static final String ARCHITECTURE_NAMESPACE     = "http://open-services.net/ns/am#";
+    public static final String ARCHITECTURE_PREFIX        = "oslc_am";
+    public static final String ARCHITECTURE_RESOURCE  = "Resource";
+    public static final String ARCHITECTURE_LINK_TYPE = "LinkType";
+    public static final String FOAF_NAMESPACE                              = "http://xmlns.com/foaf/0.1/";
+    public static final String FOAF_NAMESPACE_PREFIX                       = "foaf";
+
+    public static final String TYPE_ARCHITECTURE_RESOURCE  = ARCHITECTURE_NAMESPACE + ARCHITECTURE_RESOURCE;
+    public static final String TYPE_ARCHITECTURE_LINK_TYPE = ARCHITECTURE_NAMESPACE + ARCHITECTURE_LINK_TYPE;
+    public static final String TYPE_PERSON                = FOAF_NAMESPACE + "Person";
+}

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/ArchitectureLinkType.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/ArchitectureLinkType.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (c) 2013, 2014 IBM Corporation.
  *
  * All rights reserved. This program and the accompanying materials
@@ -34,59 +34,53 @@ import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
 import org.eclipse.lyo.oslc4j.core.model.Occurs;
 import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
 
+/**
+ * @see org.eclipse.lyo.oslc.domains.am.LinkType
+ */
 @OslcResourceShape(title = "Architecture Management LinkType Resource Shape", describes = ArchitectureConstants.TYPE_ARCHITECTURE_LINK_TYPE)
 @OslcNamespace(ArchitectureConstants.ARCHITECTURE_NAMESPACE)
 @OslcName(ArchitectureConstants.ARCHITECTURE_LINK_TYPE)
-/**
- * @see http://open-services.net/wiki/architecture-management/OSLC-Architecture-Management-Specification-Version-2.0/
- */
-public final class ArchitectureLinkType
-extends AbstractResource
-{
-	private final Set<URI>      contributors                = new TreeSet<URI>();
-    private final Set<URI>      creators                    = new TreeSet<URI>();
-    private final Set<URI>      rdfTypes                    = new TreeSet<URI>();
+@Deprecated
+public final class ArchitectureLinkType extends AbstractResource {
+    private final Set<URI> contributors = new TreeSet<URI>();
+    private final Set<URI> creators = new TreeSet<URI>();
+    private final Set<URI> rdfTypes = new TreeSet<URI>();
 
 
-    private Date     created;
-    private String   comment;
-    private String   label;
-    private String   identifier;
+    private Date created;
+    private String comment;
+    private String label;
+    private String identifier;
     private URI      instanceShape;
     private Date     modified;
     private URI      serviceProvider;
 
 
-	public ArchitectureLinkType()
-	{
-		super();
+    public ArchitectureLinkType() {
+        super();
 
-		rdfTypes.add(URI.create(ArchitectureConstants.TYPE_ARCHITECTURE_LINK_TYPE));
-	}
-
-    public ArchitectureLinkType(final URI about)
-     {
-         super(about);
-
-		rdfTypes.add(URI.create(ArchitectureConstants.TYPE_ARCHITECTURE_LINK_TYPE));
-     }
-
-    protected URI getRdfType() {
-    	return URI.create(ArchitectureConstants.TYPE_ARCHITECTURE_LINK_TYPE);
+        rdfTypes.add(URI.create(ArchitectureConstants.TYPE_ARCHITECTURE_LINK_TYPE));
     }
 
-    public void addContributor(final URI contributor)
-    {
+    public ArchitectureLinkType(final URI about) {
+        super(about);
+
+        rdfTypes.add(URI.create(ArchitectureConstants.TYPE_ARCHITECTURE_LINK_TYPE));
+    }
+
+    protected URI getRdfType() {
+        return URI.create(ArchitectureConstants.TYPE_ARCHITECTURE_LINK_TYPE);
+    }
+
+    public void addContributor(final URI contributor) {
         this.contributors.add(contributor);
     }
 
-    public void addCreator(final URI creator)
-    {
+    public void addCreator(final URI creator) {
         this.creators.add(creator);
     }
 
-    public void addRdfType(final URI rdfType)
-    {
+    public void addRdfType(final URI rdfType) {
         this.rdfTypes.add(rdfType);
     }
 
@@ -95,8 +89,7 @@ extends AbstractResource
     @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "contributor")
     @OslcRange(QmConstants.TYPE_PERSON)
     @OslcTitle("Contributors")
-    public URI[] getContributors()
-    {
+    public URI[] getContributors() {
         return contributors.toArray(new URI[contributors.size()]);
     }
 
@@ -104,8 +97,7 @@ extends AbstractResource
     @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "created")
     @OslcReadOnly
     @OslcTitle("Created")
-    public Date getCreated()
-    {
+    public Date getCreated() {
         return created;
     }
 
@@ -114,8 +106,7 @@ extends AbstractResource
     @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "creator")
     @OslcRange(ArchitectureConstants.TYPE_PERSON)
     @OslcTitle("Creators")
-    public URI[] getCreators()
-    {
+    public URI[] getCreators() {
         return creators.toArray(new URI[creators.size()]);
     }
 
@@ -123,8 +114,7 @@ extends AbstractResource
     @OslcPropertyDefinition(OslcConstants.RDFS_NAMESPACE + "label")
     @OslcTitle("Label")
     @OslcOccurs(Occurs.ExactlyOne)
-    public String getLabel()
-    {
+    public String getLabel() {
         return label;
     }
 
@@ -132,8 +122,7 @@ extends AbstractResource
     @OslcPropertyDefinition(OslcConstants.RDFS_NAMESPACE + "comment")
     @OslcTitle("Comment")
     @OslcOccurs(Occurs.ZeroOrOne)
-    public String getComment()
-    {
+    public String getComment() {
         return comment;
     }
 
@@ -142,8 +131,7 @@ extends AbstractResource
     @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "identifier")
     @OslcReadOnly
     @OslcTitle("Identifier")
-    public String getIdentifier()
-    {
+    public String getIdentifier() {
         return identifier;
     }
 
@@ -151,8 +139,7 @@ extends AbstractResource
     @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "instanceShape")
     @OslcRange(OslcConstants.TYPE_RESOURCE_SHAPE)
     @OslcTitle("Instance Shape")
-    public URI getInstanceShape()
-    {
+    public URI getInstanceShape() {
         return instanceShape;
     }
 
@@ -160,8 +147,7 @@ extends AbstractResource
     @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "modified")
     @OslcReadOnly
     @OslcTitle("Modified")
-    public Date getModified()
-    {
+    public Date getModified() {
         return modified;
     }
 
@@ -169,8 +155,7 @@ extends AbstractResource
     @OslcName("type")
     @OslcPropertyDefinition(OslcConstants.RDF_NAMESPACE + "type")
     @OslcTitle("Types")
-    public URI[] getRdfTypes()
-    {
+    public URI[] getRdfTypes() {
         return rdfTypes.toArray(new URI[rdfTypes.size()]);
     }
 
@@ -178,73 +163,59 @@ extends AbstractResource
     @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "serviceProvider")
     @OslcRange(OslcConstants.TYPE_SERVICE_PROVIDER)
     @OslcTitle("Service Provider")
-    public URI getServiceProvider()
-    {
+    public URI getServiceProvider() {
         return serviceProvider;
     }
 
-    public void setContributors(final URI[] contributors)
-    {
+    public void setContributors(final URI[] contributors) {
         this.contributors.clear();
 
-        if (contributors != null)
-        {
+        if (contributors != null) {
             this.contributors.addAll(Arrays.asList(contributors));
         }
     }
 
-    public void setCreated(final Date created)
-    {
+    public void setCreated(final Date created) {
         this.created = created;
     }
 
-    public void setCreators(final URI[] creators)
-    {
+    public void setCreators(final URI[] creators) {
         this.creators.clear();
 
-        if (creators != null)
-        {
+        if (creators != null) {
             this.creators.addAll(Arrays.asList(creators));
         }
     }
 
-    public void setLabel(final String label)
-    {
+    public void setLabel(final String label) {
         this.label = label;
     }
 
-    public void setComment(final String comment)
-    {
+    public void setComment(final String comment) {
         this.comment = comment;
     }
 
-    public void setIdentifier(final String identifier)
-    {
+    public void setIdentifier(final String identifier) {
         this.identifier = identifier;
     }
 
-    public void setInstanceShape(final URI instanceShape)
-    {
+    public void setInstanceShape(final URI instanceShape) {
         this.instanceShape = instanceShape;
     }
 
-    public void setModified(final Date modified)
-    {
+    public void setModified(final Date modified) {
         this.modified = modified;
     }
 
-    public void setRdfTypes(final URI[] rdfTypes)
-    {
+    public void setRdfTypes(final URI[] rdfTypes) {
         this.rdfTypes.clear();
 
-        if (rdfTypes != null)
-        {
+        if (rdfTypes != null) {
             this.rdfTypes.addAll(Arrays.asList(rdfTypes));
         }
     }
 
-    public void setServiceProvider(final URI serviceProvider)
-    {
+    public void setServiceProvider(final URI serviceProvider) {
         this.serviceProvider = serviceProvider;
     }
 

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/ArchitectureLinkType.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/ArchitectureLinkType.java
@@ -1,0 +1,251 @@
+/*******************************************************************************
+ * Copyright (c) 2013, 2014 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *     Michael Fiedler       - initial implementation
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcOccurs;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcRange;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcReadOnly;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
+import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
+import org.eclipse.lyo.oslc4j.core.model.Occurs;
+import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
+
+@OslcResourceShape(title = "Architecture Management LinkType Resource Shape", describes = ArchitectureConstants.TYPE_ARCHITECTURE_LINK_TYPE)
+@OslcNamespace(ArchitectureConstants.ARCHITECTURE_NAMESPACE)
+@OslcName(ArchitectureConstants.ARCHITECTURE_LINK_TYPE)
+/**
+ * @see http://open-services.net/wiki/architecture-management/OSLC-Architecture-Management-Specification-Version-2.0/
+ */
+public final class ArchitectureLinkType
+extends AbstractResource
+{
+	private final Set<URI>      contributors                = new TreeSet<URI>();
+    private final Set<URI>      creators                    = new TreeSet<URI>();
+    private final Set<URI>      rdfTypes                    = new TreeSet<URI>();
+
+
+    private Date     created;
+    private String   comment;
+    private String   label;
+    private String   identifier;
+    private URI      instanceShape;
+    private Date     modified;
+    private URI      serviceProvider;
+
+
+	public ArchitectureLinkType()
+	{
+		super();
+
+		rdfTypes.add(URI.create(ArchitectureConstants.TYPE_ARCHITECTURE_LINK_TYPE));
+	}
+
+    public ArchitectureLinkType(final URI about)
+     {
+         super(about);
+
+		rdfTypes.add(URI.create(ArchitectureConstants.TYPE_ARCHITECTURE_LINK_TYPE));
+     }
+
+    protected URI getRdfType() {
+    	return URI.create(ArchitectureConstants.TYPE_ARCHITECTURE_LINK_TYPE);
+    }
+
+    public void addContributor(final URI contributor)
+    {
+        this.contributors.add(contributor);
+    }
+
+    public void addCreator(final URI creator)
+    {
+        this.creators.add(creator);
+    }
+
+    public void addRdfType(final URI rdfType)
+    {
+        this.rdfTypes.add(rdfType);
+    }
+
+    @OslcDescription("The person(s) who are responsible for the work needed to complete the automation plan.")
+    @OslcName("contributor")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "contributor")
+    @OslcRange(QmConstants.TYPE_PERSON)
+    @OslcTitle("Contributors")
+    public URI[] getContributors()
+    {
+        return contributors.toArray(new URI[contributors.size()]);
+    }
+
+    @OslcDescription("Timestamp of resource creation.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "created")
+    @OslcReadOnly
+    @OslcTitle("Created")
+    public Date getCreated()
+    {
+        return created;
+    }
+
+    @OslcDescription("Creator or creators of resource.")
+    @OslcName("creator")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "creator")
+    @OslcRange(ArchitectureConstants.TYPE_PERSON)
+    @OslcTitle("Creators")
+    public URI[] getCreators()
+    {
+        return creators.toArray(new URI[creators.size()]);
+    }
+
+    @OslcDescription("The human readable name for this link type.")
+    @OslcPropertyDefinition(OslcConstants.RDFS_NAMESPACE + "label")
+    @OslcTitle("Label")
+    @OslcOccurs(Occurs.ExactlyOne)
+    public String getLabel()
+    {
+        return label;
+    }
+
+    @OslcDescription("Descriptive text about link type. ")
+    @OslcPropertyDefinition(OslcConstants.RDFS_NAMESPACE + "comment")
+    @OslcTitle("Comment")
+    @OslcOccurs(Occurs.ZeroOrOne)
+    public String getComment()
+    {
+        return comment;
+    }
+
+    @OslcDescription("A unique identifier for a resource. Assigned by the service provider when a resource is created. Not intended for end-user display.")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "identifier")
+    @OslcReadOnly
+    @OslcTitle("Identifier")
+    public String getIdentifier()
+    {
+        return identifier;
+    }
+
+    @OslcDescription("Resource Shape that provides hints as to resource property value-types and allowed values. ")
+    @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "instanceShape")
+    @OslcRange(OslcConstants.TYPE_RESOURCE_SHAPE)
+    @OslcTitle("Instance Shape")
+    public URI getInstanceShape()
+    {
+        return instanceShape;
+    }
+
+    @OslcDescription("Timestamp last latest resource modification.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "modified")
+    @OslcReadOnly
+    @OslcTitle("Modified")
+    public Date getModified()
+    {
+        return modified;
+    }
+
+    @OslcDescription("The resource type URIs.")
+    @OslcName("type")
+    @OslcPropertyDefinition(OslcConstants.RDF_NAMESPACE + "type")
+    @OslcTitle("Types")
+    public URI[] getRdfTypes()
+    {
+        return rdfTypes.toArray(new URI[rdfTypes.size()]);
+    }
+
+    @OslcDescription("The scope of a resource is a URI for the resource's OSLC Service Provider.")
+    @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "serviceProvider")
+    @OslcRange(OslcConstants.TYPE_SERVICE_PROVIDER)
+    @OslcTitle("Service Provider")
+    public URI getServiceProvider()
+    {
+        return serviceProvider;
+    }
+
+    public void setContributors(final URI[] contributors)
+    {
+        this.contributors.clear();
+
+        if (contributors != null)
+        {
+            this.contributors.addAll(Arrays.asList(contributors));
+        }
+    }
+
+    public void setCreated(final Date created)
+    {
+        this.created = created;
+    }
+
+    public void setCreators(final URI[] creators)
+    {
+        this.creators.clear();
+
+        if (creators != null)
+        {
+            this.creators.addAll(Arrays.asList(creators));
+        }
+    }
+
+    public void setLabel(final String label)
+    {
+        this.label = label;
+    }
+
+    public void setComment(final String comment)
+    {
+        this.comment = comment;
+    }
+
+    public void setIdentifier(final String identifier)
+    {
+        this.identifier = identifier;
+    }
+
+    public void setInstanceShape(final URI instanceShape)
+    {
+        this.instanceShape = instanceShape;
+    }
+
+    public void setModified(final Date modified)
+    {
+        this.modified = modified;
+    }
+
+    public void setRdfTypes(final URI[] rdfTypes)
+    {
+        this.rdfTypes.clear();
+
+        if (rdfTypes != null)
+        {
+            this.rdfTypes.addAll(Arrays.asList(rdfTypes));
+        }
+    }
+
+    public void setServiceProvider(final URI serviceProvider)
+    {
+        this.serviceProvider = serviceProvider;
+    }
+
+}

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/ArchitectureResource.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/ArchitectureResource.java
@@ -36,12 +36,13 @@ import org.eclipse.lyo.oslc4j.core.model.Occurs;
 import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
 import org.eclipse.lyo.oslc4j.core.model.ValueType;
 
+/**
+ * @see org.eclipse.lyo.oslc.domains.am.Resource
+ */
+@Deprecated
 @OslcResourceShape(title = "Architecture Management Resource Resource Shape", describes = ArchitectureConstants.TYPE_ARCHITECTURE_RESOURCE)
 @OslcNamespace(ArchitectureConstants.ARCHITECTURE_NAMESPACE)
 @OslcName(ArchitectureConstants.ARCHITECTURE_RESOURCE)
-/**
- * @see http://open-services.net/wiki/architecture-management/OSLC-Architecture-Management-Specification-Version-2.0/
- */
 public final class ArchitectureResource
 extends AbstractResource
 {

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/ArchitectureResource.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/ArchitectureResource.java
@@ -1,0 +1,296 @@
+/*******************************************************************************
+ * Copyright (c) 2013, 2014 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *     Michael Fiedler       - initial implementation
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcOccurs;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcRange;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcReadOnly;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
+import org.eclipse.lyo.oslc4j.core.model.Occurs;
+import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
+import org.eclipse.lyo.oslc4j.core.model.ValueType;
+
+@OslcResourceShape(title = "Architecture Management Resource Resource Shape", describes = ArchitectureConstants.TYPE_ARCHITECTURE_RESOURCE)
+@OslcNamespace(ArchitectureConstants.ARCHITECTURE_NAMESPACE)
+@OslcName(ArchitectureConstants.ARCHITECTURE_RESOURCE)
+/**
+ * @see http://open-services.net/wiki/architecture-management/OSLC-Architecture-Management-Specification-Version-2.0/
+ */
+public final class ArchitectureResource
+extends AbstractResource
+{
+	private final Set<URI>      contributors                = new TreeSet<URI>();
+    private final Set<URI>      creators                    = new TreeSet<URI>();
+    private final Set<String>   dctermsTypes                = new TreeSet<String>();
+    private final Set<URI>      rdfTypes                    = new TreeSet<URI>();
+
+
+    private Date     created;
+    private String   description;
+    private String   identifier;
+    private URI      source;
+    private URI      instanceShape;
+    private Date     modified;
+    private URI      serviceProvider;
+    private String   title;
+
+	public ArchitectureResource()
+	{
+		super();
+
+		rdfTypes.add(URI.create(ArchitectureConstants.TYPE_ARCHITECTURE_RESOURCE));
+	}
+
+    public ArchitectureResource(final URI about)
+     {
+         super(about);
+
+		rdfTypes.add(URI.create(ArchitectureConstants.TYPE_ARCHITECTURE_RESOURCE));
+     }
+
+    protected URI getRdfType() {
+    	return URI.create(ArchitectureConstants.TYPE_ARCHITECTURE_RESOURCE);
+    }
+
+    public void addContributor(final URI contributor)
+    {
+        this.contributors.add(contributor);
+    }
+
+    public void addCreator(final URI creator)
+    {
+        this.creators.add(creator);
+    }
+
+    public void addRdfType(final URI rdfType)
+    {
+        this.rdfTypes.add(rdfType);
+    }
+
+    public void addDctermsType(final String dctermsType)
+    {
+        this.dctermsTypes.add(dctermsType);
+    }
+
+
+    @OslcDescription("The person(s) who are responsible for the work needed to complete the automation plan.")
+    @OslcName("contributor")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "contributor")
+    @OslcRange(QmConstants.TYPE_PERSON)
+    @OslcTitle("Contributors")
+    public URI[] getContributors()
+    {
+        return contributors.toArray(new URI[contributors.size()]);
+    }
+
+    @OslcDescription("Timestamp of resource creation.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "created")
+    @OslcReadOnly
+    @OslcTitle("Created")
+    public Date getCreated()
+    {
+        return created;
+    }
+
+    @OslcDescription("Creator or creators of resource.")
+    @OslcName("creator")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "creator")
+    @OslcRange(ArchitectureConstants.TYPE_PERSON)
+    @OslcTitle("Creators")
+    public URI[] getCreators()
+    {
+        return creators.toArray(new URI[creators.size()]);
+    }
+
+    @OslcDescription("Descriptive text (reference: Dublin Core) about resource represented as rich text in XHTML content.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "description")
+    @OslcTitle("Description")
+    @OslcValueType(ValueType.XMLLiteral)
+    public String getDescription()
+    {
+        return description;
+    }
+
+    @OslcDescription("A unique identifier for a resource. Assigned by the service provider when a resource is created. Not intended for end-user display.")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "identifier")
+    @OslcReadOnly
+    @OslcTitle("Identifier")
+    public String getIdentifier()
+    {
+        return identifier;
+    }
+
+    @OslcDescription("Resource Shape that provides hints as to resource property value-types and allowed values. ")
+    @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "instanceShape")
+    @OslcRange(OslcConstants.TYPE_RESOURCE_SHAPE)
+    @OslcTitle("Instance Shape")
+    public URI getInstanceShape()
+    {
+        return instanceShape;
+    }
+
+    @OslcDescription("Timestamp last latest resource modification.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "modified")
+    @OslcReadOnly
+    @OslcTitle("Modified")
+    public Date getModified()
+    {
+        return modified;
+    }
+
+    @OslcDescription("The resource type URIs.")
+    @OslcName("type")
+    @OslcPropertyDefinition(OslcConstants.RDF_NAMESPACE + "type")
+    @OslcTitle("Types")
+    public URI[] getRdfTypes()
+    {
+        return rdfTypes.toArray(new URI[rdfTypes.size()]);
+    }
+
+    @OslcDescription("A short string representation for the type, example 'Defect'.")
+    @OslcName("type")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "type")
+    @OslcTitle("DCTerms Types")
+    public String[] getDctermsTypes()
+    {
+        return dctermsTypes.toArray(new String[dctermsTypes.size()]);
+    }
+
+    @OslcDescription("The resource URI a client can perform a get on to obtain the original non-OSLC AM formatted resource that was used to create this resource. ")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "source")
+    @OslcTitle("Source")
+    public URI getSource()
+    {
+        return source;
+    }
+
+    @OslcDescription("The scope of a resource is a URI for the resource's OSLC Service Provider.")
+    @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "serviceProvider")
+    @OslcRange(OslcConstants.TYPE_SERVICE_PROVIDER)
+    @OslcTitle("Service Provider")
+    public URI getServiceProvider()
+    {
+        return serviceProvider;
+    }
+
+
+    @OslcDescription("Title (reference: Dublin Core) or often a single line summary of the resource represented as rich text in XHTML content.")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "title")
+    @OslcTitle("Title")
+    @OslcValueType(ValueType.XMLLiteral)
+    public String getTitle()
+    {
+        return title;
+    }
+
+
+    public void setContributors(final URI[] contributors)
+    {
+        this.contributors.clear();
+
+        if (contributors != null)
+        {
+            this.contributors.addAll(Arrays.asList(contributors));
+        }
+    }
+
+    public void setCreated(final Date created)
+    {
+        this.created = created;
+    }
+
+    public void setCreators(final URI[] creators)
+    {
+        this.creators.clear();
+
+        if (creators != null)
+        {
+            this.creators.addAll(Arrays.asList(creators));
+        }
+    }
+
+    public void setDescription(final String description)
+    {
+        this.description = description;
+    }
+
+    public void setIdentifier(final String identifier)
+    {
+        this.identifier = identifier;
+    }
+
+    public void setInstanceShape(final URI instanceShape)
+    {
+        this.instanceShape = instanceShape;
+    }
+
+    public void setModified(final Date modified)
+    {
+        this.modified = modified;
+    }
+
+    public void setRdfTypes(final URI[] rdfTypes)
+    {
+        this.rdfTypes.clear();
+
+        if (rdfTypes != null)
+        {
+            this.rdfTypes.addAll(Arrays.asList(rdfTypes));
+        }
+    }
+
+    public void setDctermsTypes(final String[] dctermsTypes)
+    {
+        this.dctermsTypes.clear();
+
+        if (dctermsTypes != null)
+        {
+            this.dctermsTypes.addAll(Arrays.asList(dctermsTypes));
+        }
+    }
+
+    public void setSource(final URI source)
+    {
+        this.source = source;
+    }
+
+    public void setServiceProvider(final URI serviceProvider)
+    {
+        this.serviceProvider = serviceProvider;
+    }
+
+
+    public void setTitle(final String title)
+    {
+        this.title = title;
+    }
+
+}

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationConstants.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationConstants.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2012 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *     Paul McMahan <pmcmahan@us.ibm.com>        - initial implementation
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+
+public interface AutomationConstants
+{
+    String AUTOMATION_DOMAIN          = "http://open-services.net/ns/auto#";
+    String AUTOMATION_NAMESPACE       = "http://open-services.net/ns/auto#";
+    String AUTOMATION_PREFIX          = "oslc_auto";
+
+    String TYPE_AUTOMATION_PLAN       = AUTOMATION_NAMESPACE + "AutomationPlan";
+    String TYPE_AUTOMATION_REQUEST    = AUTOMATION_NAMESPACE + "AutomationRequest";
+    String TYPE_AUTOMATION_RESULT     = AUTOMATION_NAMESPACE + "AutomationResult";
+    String TYPE_PARAMETER_INSTANCE    = AUTOMATION_NAMESPACE + "ParameterInstance";
+
+    String STATE_NEW                  = AUTOMATION_NAMESPACE + "new";
+    String STATE_QUEUED               = AUTOMATION_NAMESPACE + "queued";
+    String STATE_IN_PROGRESS          = AUTOMATION_NAMESPACE + "inProgress";
+    String STATE_CANCELING            = AUTOMATION_NAMESPACE + "canceling";
+    String STATE_CANCELED             = AUTOMATION_NAMESPACE + "canceled";
+    String STATE_COMPLETE             = AUTOMATION_NAMESPACE + "complete";
+
+    String VERDICT_UNAVAILABLE        = AUTOMATION_NAMESPACE + "unavailable";
+    String VERDICT_PASSED             = AUTOMATION_NAMESPACE + "passed";
+    String VERDICT_WARNING            = AUTOMATION_NAMESPACE + "warning";
+    String VERDICT_FAILED             = AUTOMATION_NAMESPACE + "failed";
+    String VERDICT_ERROR              = AUTOMATION_NAMESPACE + "error";
+
+}

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationPlan.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationPlan.java
@@ -1,0 +1,306 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2014 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *     Paul McMahan <pmcmahan@us.ibm.com>        - initial implementation
+ *     Samuel Padgett <spadgett@us.ibm.com>      - fix getParameterDefinitions annotations
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcOccurs;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcRange;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcReadOnly;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
+import org.eclipse.lyo.oslc4j.core.model.Occurs;
+import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
+import org.eclipse.lyo.oslc4j.core.model.ValueType;
+
+@OslcResourceShape(title = "Automation Plan Resource Shape", describes = AutomationConstants.TYPE_AUTOMATION_PLAN)
+@OslcNamespace(AutomationConstants.AUTOMATION_NAMESPACE)
+/**
+ * @see http://open-services.net/wiki/automation/OSLC-Automation-Specification-Version-2.0/#Resource_AutomationPlan
+ */
+public final class AutomationPlan
+extends AbstractResource
+{
+	private final Set<URI>      contributors                = new TreeSet<URI>();
+    private final Set<URI>      creators                    = new TreeSet<URI>();
+    private final Set<URI>      rdfTypes                    = new TreeSet<URI>();
+    private final Set<String>   subjects                    = new TreeSet<String>();
+    private final Set<Property> parameterDefinitions        = new TreeSet<Property>();
+
+    private Date     created;
+    private String   description;
+    private String   identifier;
+    private URI      instanceShape;
+    private Date     modified;
+    private URI      serviceProvider;
+    private String   title;
+
+	public AutomationPlan()
+	{
+		super();
+
+		rdfTypes.add(URI.create(AutomationConstants.TYPE_AUTOMATION_PLAN));
+	}
+
+    public AutomationPlan(final URI about)
+     {
+         super(about);
+
+		rdfTypes.add(URI.create(AutomationConstants.TYPE_AUTOMATION_PLAN));
+     }
+
+    protected URI getRdfType() {
+    	return URI.create(AutomationConstants.TYPE_AUTOMATION_PLAN);
+    }
+
+    public void addContributor(final URI contributor)
+    {
+        this.contributors.add(contributor);
+    }
+
+    public void addCreator(final URI creator)
+    {
+        this.creators.add(creator);
+    }
+
+    public void addRdfType(final URI rdfType)
+    {
+        this.rdfTypes.add(rdfType);
+    }
+
+    public void addSubject(final String subject)
+    {
+        this.subjects.add(subject);
+    }
+
+    public void addParameterDefinition(final Property parameter)
+    {
+        this.parameterDefinitions.add(parameter);
+    }
+
+    @OslcDescription("The person(s) who are responsible for the work needed to complete the automation plan.")
+    @OslcName("contributor")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "contributor")
+    @OslcRange(QmConstants.TYPE_PERSON)
+    @OslcTitle("Contributors")
+    public URI[] getContributors()
+    {
+        return contributors.toArray(new URI[contributors.size()]);
+    }
+
+    @OslcDescription("Timestamp of resource creation.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "created")
+    @OslcReadOnly
+    @OslcTitle("Created")
+    public Date getCreated()
+    {
+        return created;
+    }
+
+    @OslcDescription("Creator or creators of resource.")
+    @OslcName("creator")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "creator")
+    @OslcRange(QmConstants.TYPE_PERSON)
+    @OslcTitle("Creators")
+    public URI[] getCreators()
+    {
+        return creators.toArray(new URI[creators.size()]);
+    }
+
+    @OslcDescription("Descriptive text (reference: Dublin Core) about resource represented as rich text in XHTML content.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "description")
+    @OslcTitle("Description")
+    @OslcValueType(ValueType.XMLLiteral)
+    public String getDescription()
+    {
+        return description;
+    }
+
+    @OslcDescription("A unique identifier for a resource. Assigned by the service provider when a resource is created. Not intended for end-user display.")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "identifier")
+    @OslcReadOnly
+    @OslcTitle("Identifier")
+    public String getIdentifier()
+    {
+        return identifier;
+    }
+
+    @OslcDescription("Resource Shape that provides hints as to resource property value-types and allowed values. ")
+    @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "instanceShape")
+    @OslcRange(OslcConstants.TYPE_RESOURCE_SHAPE)
+    @OslcTitle("Instance Shape")
+    public URI getInstanceShape()
+    {
+        return instanceShape;
+    }
+
+    @OslcDescription("Timestamp last latest resource modification.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "modified")
+    @OslcReadOnly
+    @OslcTitle("Modified")
+    public Date getModified()
+    {
+        return modified;
+    }
+
+    @OslcDescription("The resource type URIs.")
+    @OslcName("type")
+    @OslcPropertyDefinition(OslcConstants.RDF_NAMESPACE + "type")
+    @OslcTitle("Types")
+    public URI[] getRdfTypes()
+    {
+        return rdfTypes.toArray(new URI[rdfTypes.size()]);
+    }
+
+    @OslcDescription("The scope of a resource is a URI for the resource's OSLC Service Provider.")
+    @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "serviceProvider")
+    @OslcRange(OslcConstants.TYPE_SERVICE_PROVIDER)
+    @OslcTitle("Service Provider")
+    public URI getServiceProvider()
+    {
+        return serviceProvider;
+    }
+
+    @OslcDescription("Tag or keyword for a resource. Each occurrence of a dcterms:subject property denotes an additional tag for the resource.")
+    @OslcName("subject")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "subject")
+    @OslcReadOnly(false)
+    @OslcTitle("Subjects")
+    public String[] getSubjects()
+    {
+        return subjects.toArray(new String[subjects.size()]);
+    }
+
+    @OslcDescription("Title (reference: Dublin Core) or often a single line summary of the resource represented as rich text in XHTML content.")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "title")
+    @OslcTitle("Title")
+    @OslcValueType(ValueType.XMLLiteral)
+    public String getTitle()
+    {
+        return title;
+    }
+
+    @OslcDescription("The parameter definitions for the automation plan.")
+    @OslcOccurs(Occurs.ZeroOrMany)
+    @OslcName("parameterDefinition")
+    @OslcPropertyDefinition(AutomationConstants.AUTOMATION_NAMESPACE + "parameterDefinition")
+    @OslcValueType(ValueType.LocalResource)
+    @OslcTitle("Parameter Definitions")
+    public Property[] getParameterDefinitions()
+    {
+        return parameterDefinitions.toArray(new Property[parameterDefinitions.size()]);
+    }
+
+
+    public void setContributors(final URI[] contributors)
+    {
+        this.contributors.clear();
+
+        if (contributors != null)
+        {
+            this.contributors.addAll(Arrays.asList(contributors));
+        }
+    }
+
+    public void setCreated(final Date created)
+    {
+        this.created = created;
+    }
+
+    public void setCreators(final URI[] creators)
+    {
+        this.creators.clear();
+
+        if (creators != null)
+        {
+            this.creators.addAll(Arrays.asList(creators));
+        }
+    }
+
+    public void setDescription(final String description)
+    {
+        this.description = description;
+    }
+
+    public void setIdentifier(final String identifier)
+    {
+        this.identifier = identifier;
+    }
+
+    public void setInstanceShape(final URI instanceShape)
+    {
+        this.instanceShape = instanceShape;
+    }
+
+    public void setModified(final Date modified)
+    {
+        this.modified = modified;
+    }
+
+    public void setRdfTypes(final URI[] rdfTypes)
+    {
+        this.rdfTypes.clear();
+
+        if (rdfTypes != null)
+        {
+            this.rdfTypes.addAll(Arrays.asList(rdfTypes));
+        }
+    }
+
+    public void setServiceProvider(final URI serviceProvider)
+    {
+        this.serviceProvider = serviceProvider;
+    }
+
+    public void setSubjects(final String[] subjects)
+    {
+        this.subjects.clear();
+
+        if (subjects != null)
+        {
+            this.subjects.addAll(Arrays.asList(subjects));
+        }
+    }
+
+    public void setTitle(final String title)
+    {
+        this.title = title;
+    }
+
+    public void setParameterDefinitions(final Property[] parameterDefinitions)
+    {
+        this.parameterDefinitions.clear();
+
+        if (parameterDefinitions != null)
+        {
+            this.parameterDefinitions.addAll(Arrays.asList(parameterDefinitions));
+        }
+    }
+
+}

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationPlan.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationPlan.java
@@ -37,6 +37,10 @@ import org.eclipse.lyo.oslc4j.core.model.Occurs;
 import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
 import org.eclipse.lyo.oslc4j.core.model.ValueType;
 
+/**
+ * @see org.eclipse.lyo.oslc.domains.auto.AutomationPlan
+ */
+@Deprecated
 @OslcResourceShape(title = "Automation Plan Resource Shape", describes = AutomationConstants.TYPE_AUTOMATION_PLAN)
 @OslcNamespace(AutomationConstants.AUTOMATION_NAMESPACE)
 /**

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationRequest.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationRequest.java
@@ -38,11 +38,12 @@ import org.eclipse.lyo.oslc4j.core.model.Occurs;
 import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
 import org.eclipse.lyo.oslc4j.core.model.ValueType;
 
+/**
+ * @see org.eclipse.lyo.oslc.domains.auto.AutomationRequest
+ */
+@Deprecated
 @OslcResourceShape(title = "Automation Request Resource Shape", describes = AutomationConstants.TYPE_AUTOMATION_REQUEST)
 @OslcNamespace(AutomationConstants.AUTOMATION_NAMESPACE)
-/**
- * @see http://open-services.net/wiki/automation/OSLC-Automation-Specification-Version-2.0/#Resource_AutomationRequest
- */
 public final class AutomationRequest
 extends AbstractResource
 {

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationRequest.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationRequest.java
@@ -1,0 +1,379 @@
+/*******************************************************************************
+ * Copyright (c) 2012 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *     Paul McMahan <pmcmahan@us.ibm.com>        - initial implementation
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcAllowedValue;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcOccurs;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcRange;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcReadOnly;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
+import org.eclipse.lyo.oslc4j.core.model.Link;
+import org.eclipse.lyo.oslc4j.core.model.Occurs;
+import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
+import org.eclipse.lyo.oslc4j.core.model.ValueType;
+
+@OslcResourceShape(title = "Automation Request Resource Shape", describes = AutomationConstants.TYPE_AUTOMATION_REQUEST)
+@OslcNamespace(AutomationConstants.AUTOMATION_NAMESPACE)
+/**
+ * @see http://open-services.net/wiki/automation/OSLC-Automation-Specification-Version-2.0/#Resource_AutomationRequest
+ */
+public final class AutomationRequest
+extends AbstractResource
+{
+	private final Set<URI>      contributors                = new TreeSet<URI>();
+    private final Set<URI>      creators                    = new TreeSet<URI>();
+    private final Set<URI>      rdfTypes                    = new TreeSet<URI>();
+    private final Set<String>   subjects                    = new TreeSet<String>();
+    private final Set<URI>      states                      = new TreeSet<URI>();
+    private final Set<ParameterInstance> inputParameters    = new TreeSet<ParameterInstance>();
+
+    private Date     created;
+    private String   description;
+    private String   identifier;
+    private URI      instanceShape;
+    private Date     modified;
+    private URI      serviceProvider;
+    private String   title;
+    private URI      desiredState;
+    private Link      executesAutomationPlan;
+
+	public AutomationRequest()
+	{
+		super();
+
+		rdfTypes.add(URI.create(AutomationConstants.TYPE_AUTOMATION_REQUEST));
+	}
+
+    public AutomationRequest(final URI about)
+     {
+         super(about);
+
+		rdfTypes.add(URI.create(AutomationConstants.TYPE_AUTOMATION_REQUEST));
+     }
+
+    protected URI getRdfType() {
+    	return URI.create(AutomationConstants.TYPE_AUTOMATION_REQUEST);
+    }
+
+    public void addContributor(final URI contributor)
+    {
+        this.contributors.add(contributor);
+    }
+
+    public void addCreator(final URI creator)
+    {
+        this.creators.add(creator);
+    }
+
+    public void addRdfType(final URI rdfType)
+    {
+        this.rdfTypes.add(rdfType);
+    }
+
+    public void addSubject(final String subject)
+    {
+        this.subjects.add(subject);
+    }
+
+    public void addState(final URI state)
+    {
+        this.states.add(state);
+    }
+
+    public void addInputParameter(final ParameterInstance parameter)
+    {
+        this.inputParameters.add(parameter);
+    }
+
+    @OslcDescription("The person(s) who are responsible for the work needed to complete the automation request.")
+    @OslcName("contributor")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "contributor")
+    @OslcRange(QmConstants.TYPE_PERSON)
+    @OslcTitle("Contributors")
+    public URI[] getContributors()
+    {
+        return contributors.toArray(new URI[contributors.size()]);
+    }
+
+    @OslcDescription("Timestamp of resource creation.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "created")
+    @OslcReadOnly
+    @OslcTitle("Created")
+    public Date getCreated()
+    {
+        return created;
+    }
+
+    @OslcDescription("Creator or creators of resource.")
+    @OslcName("creator")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "creator")
+    @OslcRange(QmConstants.TYPE_PERSON)
+    @OslcTitle("Creators")
+    public URI[] getCreators()
+    {
+        return creators.toArray(new URI[creators.size()]);
+    }
+
+    @OslcDescription("Descriptive text (reference: Dublin Core) about resource represented as rich text in XHTML content.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "description")
+    @OslcTitle("Description")
+    @OslcValueType(ValueType.XMLLiteral)
+    public String getDescription()
+    {
+        return description;
+    }
+
+    @OslcDescription("A unique identifier for a resource. Assigned by the service provider when a resource is created. Not intended for end-user display.")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "identifier")
+    @OslcReadOnly
+    @OslcTitle("Identifier")
+    public String getIdentifier()
+    {
+        return identifier;
+    }
+
+    @OslcDescription("Resource Shape that provides hints as to resource property value-types and allowed values. ")
+    @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "instanceShape")
+    @OslcRange(OslcConstants.TYPE_RESOURCE_SHAPE)
+    @OslcTitle("Instance Shape")
+    public URI getInstanceShape()
+    {
+        return instanceShape;
+    }
+
+    @OslcDescription("Timestamp last latest resource modification.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "modified")
+    @OslcReadOnly
+    @OslcTitle("Modified")
+    public Date getModified()
+    {
+        return modified;
+    }
+
+    @OslcDescription("The resource type URIs.")
+    @OslcName("type")
+    @OslcPropertyDefinition(OslcConstants.RDF_NAMESPACE + "type")
+    @OslcTitle("Types")
+    public URI[] getRdfTypes()
+    {
+        return rdfTypes.toArray(new URI[rdfTypes.size()]);
+    }
+
+    @OslcDescription("The scope of a resource is a URI for the resource's OSLC Service Provider.")
+    @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "serviceProvider")
+    @OslcTitle("Service Provider")
+    public URI getServiceProvider()
+    {
+        return serviceProvider;
+    }
+
+    @OslcDescription("Used to indicate the desired state of the Automation Request based on values defined by the service provider.")
+    @OslcPropertyDefinition(AutomationConstants.AUTOMATION_NAMESPACE + "desiredState")
+    @OslcName("desiredState")
+    @OslcOccurs(Occurs.ZeroOrOne)
+    @OslcTitle("Desired State")
+    @OslcAllowedValue({
+    	AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_NEW,
+		AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_IN_PROGRESS,
+		AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_QUEUED,
+		AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_CANCELING,
+		AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_CANCELED,
+		AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_COMPLETE})
+    public URI getDesiredState()
+    {
+        return desiredState;
+    }
+
+    @OslcDescription("Automation Plan run by the Automation Request.")
+    @OslcPropertyDefinition(AutomationConstants.AUTOMATION_NAMESPACE + "executesAutomationPlan")
+    @OslcName("executesAutomationPlan")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcTitle("Executes Automation Plan")
+    public Link getExecutesAutomationPlan()
+    {
+        return executesAutomationPlan;
+    }
+
+    @OslcDescription("Tag or keyword for a resource. Each occurrence of a dcterms:subject property denotes an additional tag for the resource.")
+    @OslcName("subject")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "subject")
+    @OslcReadOnly(false)
+    @OslcTitle("Subjects")
+    public String[] getSubjects()
+    {
+        return subjects.toArray(new String[subjects.size()]);
+    }
+
+    @OslcDescription("Title (reference: Dublin Core) or often a single line summary of the resource represented as rich text in XHTML content.")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "title")
+    @OslcTitle("Title")
+    @OslcValueType(ValueType.XMLLiteral)
+    public String getTitle()
+    {
+        return title;
+    }
+
+    @OslcDescription("Used to indicate the state of the automation request based on values defined by the service provider.")
+    @OslcOccurs(Occurs.OneOrMany)
+    @OslcReadOnly(true)
+    @OslcName("state")
+    @OslcPropertyDefinition(AutomationConstants.AUTOMATION_NAMESPACE + "state")
+    @OslcTitle("States")
+    @OslcAllowedValue({
+    	AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_NEW,
+		AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_IN_PROGRESS,
+		AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_QUEUED,
+		AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_CANCELING,
+		AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_CANCELED,
+		AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_COMPLETE})
+    public URI[] getStates()
+    {
+        return states.toArray(new URI[states.size()]);
+    }
+
+
+    @OslcDescription("Parameters provided when Automation Requests are created.")
+    @OslcOccurs(Occurs.ZeroOrMany)
+    @OslcName("inputParameter")
+    @OslcPropertyDefinition(AutomationConstants.AUTOMATION_NAMESPACE + "inputParameter")
+    @OslcReadOnly(false)
+    @OslcTitle("Input Parameter")
+    public ParameterInstance[] getInputParameters()
+    {
+        return inputParameters.toArray(new ParameterInstance[inputParameters.size()]);
+    }
+
+    public void setContributors(final URI[] contributors)
+    {
+        this.contributors.clear();
+
+        if (contributors != null)
+        {
+            this.contributors.addAll(Arrays.asList(contributors));
+        }
+    }
+
+    public void setCreated(final Date created)
+    {
+        this.created = created;
+    }
+
+    public void setCreators(final URI[] creators)
+    {
+        this.creators.clear();
+
+        if (creators != null)
+        {
+            this.creators.addAll(Arrays.asList(creators));
+        }
+    }
+
+    public void setDescription(final String description)
+    {
+        this.description = description;
+    }
+
+    public void setIdentifier(final String identifier)
+    {
+        this.identifier = identifier;
+    }
+
+    public void setInstanceShape(final URI instanceShape)
+    {
+        this.instanceShape = instanceShape;
+    }
+
+    public void setModified(final Date modified)
+    {
+        this.modified = modified;
+    }
+
+    public void setRdfTypes(final URI[] rdfTypes)
+    {
+        this.rdfTypes.clear();
+
+        if (rdfTypes != null)
+        {
+            this.rdfTypes.addAll(Arrays.asList(rdfTypes));
+        }
+    }
+
+    public void setServiceProvider(final URI serviceProvider)
+    {
+        this.serviceProvider = serviceProvider;
+    }
+
+    public void setDesiredState(final URI desiredState)
+    {
+        this.desiredState = desiredState;
+    }
+
+    public void setExecutesAutomationPlan(final Link executesAutomationPlan)
+    {
+        this.executesAutomationPlan = executesAutomationPlan;
+    }
+
+    public void setSubjects(final String[] subjects)
+    {
+        this.subjects.clear();
+
+        if (subjects != null)
+        {
+            this.subjects.addAll(Arrays.asList(subjects));
+        }
+    }
+
+    public void setTitle(final String title)
+    {
+        this.title = title;
+    }
+
+    public void setStates(final URI[] states)
+    {
+        this.states.clear();
+
+        if (states != null)
+        {
+            this.states.addAll(Arrays.asList(states));
+        }
+    }
+
+    public void setInputParameters(final ParameterInstance[] parameters)
+    {
+        this.inputParameters.clear();
+
+        if (parameters != null)
+        {
+            this.inputParameters.addAll(Arrays.asList(parameters));
+        }
+    }
+
+}

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationResult.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationResult.java
@@ -38,11 +38,12 @@ import org.eclipse.lyo.oslc4j.core.model.Occurs;
 import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
 import org.eclipse.lyo.oslc4j.core.model.ValueType;
 
+/**
+ * @see org.eclipse.lyo.oslc.domains.auto.AutomationResult
+ */
+@Deprecated
 @OslcResourceShape(title = "Automation Result Resource Shape", describes = AutomationConstants.TYPE_AUTOMATION_RESULT)
 @OslcNamespace(AutomationConstants.AUTOMATION_NAMESPACE)
-/**
- * @see http://open-services.net/wiki/automation/OSLC-Automation-Specification-Version-2.0/#Resource_AutomationResult
- */
 public final class AutomationResult
 extends AbstractResource
 {

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationResult.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationResult.java
@@ -1,0 +1,465 @@
+/*******************************************************************************
+ * Copyright (c) 2012 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *     Paul McMahan <pmcmahan@us.ibm.com>        - initial implementation
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcAllowedValue;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcOccurs;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcRange;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcReadOnly;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
+import org.eclipse.lyo.oslc4j.core.model.Link;
+import org.eclipse.lyo.oslc4j.core.model.Occurs;
+import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
+import org.eclipse.lyo.oslc4j.core.model.ValueType;
+
+@OslcResourceShape(title = "Automation Result Resource Shape", describes = AutomationConstants.TYPE_AUTOMATION_RESULT)
+@OslcNamespace(AutomationConstants.AUTOMATION_NAMESPACE)
+/**
+ * @see http://open-services.net/wiki/automation/OSLC-Automation-Specification-Version-2.0/#Resource_AutomationResult
+ */
+public final class AutomationResult
+extends AbstractResource
+{
+	private final Set<URI>      contributors                = new TreeSet<URI>();
+    private final Set<URI>      creators                    = new TreeSet<URI>();
+    private final Set<URI>      rdfTypes                    = new TreeSet<URI>();
+    private final Set<String>   subjects                    = new TreeSet<String>();
+    private final Set<URI>      states                      = new TreeSet<URI>();
+    private final Set<URI>      verdicts                    = new TreeSet<URI>();
+    private final Set<URI>      contributions               = new TreeSet<URI>();
+    private final Set<ParameterInstance> inputParameters    = new TreeSet<ParameterInstance>();
+    private final Set<ParameterInstance> outputParameters   = new TreeSet<ParameterInstance>();
+
+    private Date     created;
+    private String   identifier;
+    private URI      instanceShape;
+    private Date     modified;
+    private URI      serviceProvider;
+    private String   title;
+    private URI      desiredState;
+    private Link      producedByAutomationRequest;
+    private Link      reportsOnAutomationPlan;
+
+	public AutomationResult()
+	{
+		super();
+
+		rdfTypes.add(URI.create(AutomationConstants.TYPE_AUTOMATION_RESULT));
+	}
+
+    public AutomationResult(final URI about)
+     {
+         super(about);
+
+		rdfTypes.add(URI.create(AutomationConstants.TYPE_AUTOMATION_RESULT));
+     }
+
+    protected URI getRdfType() {
+    	return URI.create(AutomationConstants.TYPE_AUTOMATION_RESULT);
+    }
+
+    public void addContributor(final URI contributor)
+    {
+        this.contributors.add(contributor);
+    }
+
+    public void addCreator(final URI creator)
+    {
+        this.creators.add(creator);
+    }
+
+    public void addRdfType(final URI rdfType)
+    {
+        this.rdfTypes.add(rdfType);
+    }
+
+    public void addSubject(final String subject)
+    {
+        this.subjects.add(subject);
+    }
+
+    public void addState(final URI state)
+    {
+        this.states.add(state);
+    }
+
+    public void addVerdict(final URI verdict)
+    {
+        this.verdicts.add(verdict);
+    }
+
+    public void addContribution(final URI contribution)
+    {
+        this.contributions.add(contribution);
+    }
+
+    public void addInputParameter(final ParameterInstance parameter)
+    {
+        this.inputParameters.add(parameter);
+    }
+
+    public void addOutputParameter(final ParameterInstance parameter)
+    {
+        this.outputParameters.add(parameter);
+    }
+
+    @OslcDescription("The person(s) who are responsible for the work needed to complete the automation result.")
+    @OslcName("contributor")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "contributor")
+    @OslcRange(QmConstants.TYPE_PERSON)
+    @OslcTitle("Contributors")
+    public URI[] getContributors()
+    {
+        return contributors.toArray(new URI[contributors.size()]);
+    }
+
+    @OslcDescription("Timestamp of resource creation.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "created")
+    @OslcReadOnly
+    @OslcTitle("Created")
+    public Date getCreated()
+    {
+        return created;
+    }
+
+    @OslcDescription("Creator or creators of resource.")
+    @OslcName("creator")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "creator")
+    @OslcRange(QmConstants.TYPE_PERSON)
+    @OslcTitle("Creators")
+    public URI[] getCreators()
+    {
+        return creators.toArray(new URI[creators.size()]);
+    }
+
+    @OslcDescription("A unique identifier for a resource. Assigned by the service provider when a resource is created. Not intended for end-user display.")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "identifier")
+    @OslcReadOnly
+    @OslcTitle("Identifier")
+    public String getIdentifier()
+    {
+        return identifier;
+    }
+
+    @OslcDescription("Resource Shape that provides hints as to resource property value-types and allowed values. ")
+    @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "instanceShape")
+    @OslcRange(OslcConstants.TYPE_RESOURCE_SHAPE)
+    @OslcTitle("Instance Shape")
+    public URI getInstanceShape()
+    {
+        return instanceShape;
+    }
+
+    @OslcDescription("Timestamp last latest resource modification.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "modified")
+    @OslcReadOnly
+    @OslcTitle("Modified")
+    public Date getModified()
+    {
+        return modified;
+    }
+
+    @OslcDescription("The resource type URIs.")
+    @OslcName("type")
+    @OslcPropertyDefinition(OslcConstants.RDF_NAMESPACE + "type")
+    @OslcTitle("Types")
+    public URI[] getRdfTypes()
+    {
+        return rdfTypes.toArray(new URI[rdfTypes.size()]);
+    }
+
+    @OslcDescription("The scope of a resource is a URI for the resource's OSLC Service Provider.")
+    @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "serviceProvider")
+    @OslcRange(OslcConstants.TYPE_SERVICE_PROVIDER)
+    @OslcTitle("Service Provider")
+    public URI getServiceProvider()
+    {
+        return serviceProvider;
+    }
+
+    @OslcDescription("Tag or keyword for a resource. Each occurrence of a dcterms:subject property denotes an additional tag for the resource.")
+    @OslcName("subject")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "subject")
+    @OslcReadOnly(false)
+    @OslcTitle("Subjects")
+    public String[] getSubjects()
+    {
+        return subjects.toArray(new String[subjects.size()]);
+    }
+
+    @OslcDescription("Title (reference: Dublin Core) or often a single line summary of the resource represented as rich text in XHTML content.")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "title")
+    @OslcTitle("Title")
+    @OslcValueType(ValueType.XMLLiteral)
+    public String getTitle()
+    {
+        return title;
+    }
+
+    @OslcDescription("Used to indicate the state of the automation result based on values defined by the service provider.")
+    @OslcOccurs(Occurs.OneOrMany)
+    @OslcReadOnly(true)
+    @OslcName("state")
+    @OslcPropertyDefinition(AutomationConstants.AUTOMATION_NAMESPACE + "state")
+    @OslcTitle("State")
+    @OslcAllowedValue({
+    	AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_NEW,
+		AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_IN_PROGRESS,
+		AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_QUEUED,
+		AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_CANCELING,
+		AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_CANCELED,
+		AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_COMPLETE})
+    public URI[] getStates()
+    {
+        return states.toArray(new URI[states.size()]);
+    }
+
+    @OslcDescription("A result contribution associated with this automation result.")
+    @OslcOccurs(Occurs.ZeroOrMany)
+    @OslcName("contribution")
+    @OslcPropertyDefinition(AutomationConstants.AUTOMATION_NAMESPACE + "contribution")
+    @OslcTitle("Contribution")
+    public URI[] getContributions()
+    {
+        return contributions.toArray(new URI[contributions.size()]);
+    }
+
+    @OslcDescription("Used to indicate the verdict of the automation result based on values defined by the service provider.")
+    @OslcOccurs(Occurs.OneOrMany)
+    @OslcName("verdict")
+    @OslcPropertyDefinition(AutomationConstants.AUTOMATION_NAMESPACE + "verdict")
+    @OslcTitle("Verdict")
+    @OslcAllowedValue({
+    	AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.VERDICT_PASSED,
+    	AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.VERDICT_FAILED,
+    	AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.VERDICT_WARNING,
+    	AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.VERDICT_ERROR,
+    	AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.VERDICT_UNAVAILABLE})
+    public URI[] getVerdicts()
+    {
+        return verdicts.toArray(new URI[verdicts.size()]);
+    }
+
+    @OslcDescription("Used to indicate the desired state of the Automation Request based on values defined by the service provider.")
+    @OslcPropertyDefinition(AutomationConstants.AUTOMATION_NAMESPACE + "desiredState")
+    @OslcName("desiredState")
+    @OslcOccurs(Occurs.ZeroOrOne)
+    @OslcTitle("Desired State")
+    @OslcAllowedValue({
+    	AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_NEW,
+		AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_IN_PROGRESS,
+		AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_QUEUED,
+		AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_CANCELING,
+		AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_CANCELED,
+		AutomationConstants.AUTOMATION_NAMESPACE + AutomationConstants.STATE_COMPLETE})
+    public URI getDesiredState()
+    {
+        return desiredState;
+    }
+
+    @OslcDescription("Automation Request which produced the Automation Result.")
+    @OslcPropertyDefinition(AutomationConstants.AUTOMATION_NAMESPACE + "producedByAutomationRequest")
+    @OslcName("producedByAutomationRequest")
+    @OslcOccurs(Occurs.ZeroOrOne)
+    @OslcTitle("Produced By Automation Request")
+    public Link getProducedByAutomationRequest()
+    {
+        return producedByAutomationRequest;
+    }
+
+    @OslcDescription("Automation Plan which the Automation Result reports on.")
+    @OslcPropertyDefinition(AutomationConstants.AUTOMATION_NAMESPACE + "reportsOnAutomationPlan")
+    @OslcName("reportsOnAutomationPlan")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcTitle("Reports On Automation Plan")
+    public Link getReportsOnAutomationPlan()
+    {
+        return reportsOnAutomationPlan;
+    }
+
+    @OslcDescription("A copy of the parameters provided during creation of the Automation Request which produced this Automation Result.")
+    @OslcOccurs(Occurs.ZeroOrMany)
+    @OslcName("inputParameter")
+    @OslcPropertyDefinition(AutomationConstants.AUTOMATION_NAMESPACE + "inputParameter")
+    @OslcReadOnly(true)
+    @OslcTitle("Input Parameter")
+    public ParameterInstance[] getInputParameters()
+    {
+        return inputParameters.toArray(new ParameterInstance[inputParameters.size()]);
+    }
+
+    @OslcDescription("Automation Result output parameters are parameters associated with the automation execution which produced this Result. This includes the final value of all parameters used to initiate the execution and any additional parameters which may have been created during automation execution by the service provider or external agents.")
+    @OslcOccurs(Occurs.ZeroOrMany)
+    @OslcName("outputParameter")
+    @OslcPropertyDefinition(AutomationConstants.AUTOMATION_NAMESPACE + "outputParameter")
+    @OslcTitle("Output Parameter")
+    public ParameterInstance[] getOutputParameters()
+    {
+        return outputParameters.toArray(new ParameterInstance[outputParameters.size()]);
+    }
+
+    public void setContributors(final URI[] contributors)
+    {
+        this.contributors.clear();
+
+        if (contributors != null)
+        {
+            this.contributors.addAll(Arrays.asList(contributors));
+        }
+    }
+
+    public void setCreated(final Date created)
+    {
+        this.created = created;
+    }
+
+    public void setCreators(final URI[] creators)
+    {
+        this.creators.clear();
+
+        if (creators != null)
+        {
+            this.creators.addAll(Arrays.asList(creators));
+        }
+    }
+
+    public void setIdentifier(final String identifier)
+    {
+        this.identifier = identifier;
+    }
+
+    public void setInstanceShape(final URI instanceShape)
+    {
+        this.instanceShape = instanceShape;
+    }
+
+    public void setModified(final Date modified)
+    {
+        this.modified = modified;
+    }
+
+    public void setRdfTypes(final URI[] rdfTypes)
+    {
+        this.rdfTypes.clear();
+
+        if (rdfTypes != null)
+        {
+            this.rdfTypes.addAll(Arrays.asList(rdfTypes));
+        }
+    }
+
+    public void setServiceProvider(final URI serviceProvider)
+    {
+        this.serviceProvider = serviceProvider;
+    }
+
+    public void setSubjects(final String[] subjects)
+    {
+        this.subjects.clear();
+
+        if (subjects != null)
+        {
+            this.subjects.addAll(Arrays.asList(subjects));
+        }
+    }
+
+    public void setTitle(final String title)
+    {
+        this.title = title;
+    }
+
+    public void setStates(final URI[] states)
+    {
+        this.states.clear();
+
+        if (states != null)
+        {
+            this.states.addAll(Arrays.asList(states));
+        }
+    }
+
+    public void setVerdicts(final URI[] verdicts)
+    {
+        this.verdicts.clear();
+
+        if (verdicts != null)
+        {
+            this.verdicts.addAll(Arrays.asList(verdicts));
+        }
+    }
+
+    public void setContributions(final URI[] contributions)
+    {
+        this.contributions.clear();
+
+        if (contributions != null)
+        {
+            this.contributions.addAll(Arrays.asList(contributions));
+        }
+    }
+
+    public void setDesiredState(final URI desiredState)
+    {
+        this.desiredState = desiredState;
+    }
+
+    public void setProducedByAutomationRequest(final Link producedByAutomationRequest)
+    {
+        this.producedByAutomationRequest = producedByAutomationRequest;
+    }
+
+    public void setReportsOnAutomationPlan(final Link reportsOnAutomationPlan)
+    {
+        this.reportsOnAutomationPlan = reportsOnAutomationPlan;
+    }
+
+    public void setInputParameters(final ParameterInstance[] parameters)
+    {
+        this.inputParameters.clear();
+
+        if (parameters != null)
+        {
+            this.inputParameters.addAll(Arrays.asList(parameters));
+        }
+    }
+
+    public void setOutputParameters(final ParameterInstance[] parameters)
+    {
+        this.outputParameters.clear();
+
+        if (parameters != null)
+        {
+            this.outputParameters.addAll(Arrays.asList(parameters));
+        }
+    }
+
+
+}

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/ChangeRequest.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/ChangeRequest.java
@@ -43,6 +43,10 @@ import org.eclipse.lyo.oslc4j.core.model.Occurs;
 import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
 import org.eclipse.lyo.oslc4j.core.model.ValueType;
 
+/**
+ * @see org.eclipse.lyo.oslc.domains.cm.ChangeRequest
+ */
+@Deprecated
 @OslcNamespace(CmConstants.CHANGE_MANAGEMENT_NAMESPACE)
 @OslcResourceShape(title = "Change Request Resource Shape", describes = CmConstants.TYPE_CHANGE_REQUEST)
 public final class ChangeRequest

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/ChangeRequest.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/ChangeRequest.java
@@ -1,0 +1,857 @@
+/*******************************************************************************
+ * Copyright (c) 2012 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *     Russell Boykin       - initial API and implementation
+ *     Alberto Giammaria    - initial API and implementation
+ *     Chris Peters         - initial API and implementation
+ *     Gianluca Bernardini  - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcAllowedValue;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcOccurs;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcRange;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcReadOnly;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
+import org.eclipse.lyo.oslc4j.core.model.Link;
+import org.eclipse.lyo.oslc4j.core.model.Occurs;
+import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
+import org.eclipse.lyo.oslc4j.core.model.ValueType;
+
+@OslcNamespace(CmConstants.CHANGE_MANAGEMENT_NAMESPACE)
+@OslcResourceShape(title = "Change Request Resource Shape", describes = CmConstants.TYPE_CHANGE_REQUEST)
+public final class ChangeRequest
+       extends AbstractResource
+{
+    private final Set<Link>     affectedByDefects           = new HashSet<Link>();
+    private final Set<Link>     affectsPlanItems            = new HashSet<Link>();
+    private final Set<Link>     affectsRequirements         = new HashSet<Link>();
+    private final Set<Link>     affectsTestResults          = new HashSet<Link>();
+    private final Set<Link>     blocksTestExecutionRecords  = new HashSet<Link>();
+    private final Set<URI>      contributors                = new TreeSet<URI>();
+    private final Set<URI>      creators                    = new TreeSet<URI>();
+    private final Set<String>   dctermsTypes                = new TreeSet<String>();
+    private final Set<Link>     implementsRequirements      = new HashSet<Link>();
+    private final Set<Link>     relatedChangeRequests       = new HashSet<Link>();
+    private final Set<Link>     relatedResources            = new HashSet<Link>(); // TODO - Extension to point to any other OSLC resource(s).
+    private final Set<Link>     relatedTestCases            = new HashSet<Link>();
+    private final Set<Link>     relatedTestExecutionRecords = new HashSet<Link>();
+    private final Set<Link>     relatedTestPlans            = new HashSet<Link>();
+    private final Set<Link>     relatedTestScripts          = new HashSet<Link>();
+    private final Set<String>   subjects                    = new TreeSet<String>();
+    private final Set<Link>     testedByTestCases           = new HashSet<Link>();
+    private final Set<Link>     tracksChangeSets            = new HashSet<Link>();
+    private final Set<Link>     tracksRequirements          = new HashSet<Link>();
+    private final Set<URI>      rdfTypes                    = new TreeSet<URI>();
+
+    private Boolean  approved;
+    private Boolean  closed;
+    private Date     closeDate;
+    private Date     created;
+    private String   description;
+    private URI      discussedBy;
+    private Boolean  fixed;
+    private String   identifier;
+    private Boolean  inProgress;
+    private URI      instanceShape;
+    private Date     modified;
+    private Boolean  reviewed;
+    private URI      serviceProvider;
+    private String   shortTitle;
+    private String   status;
+    private String   title;
+    private Boolean  verified;
+
+    public ChangeRequest()
+           throws URISyntaxException
+    {
+        super();
+
+        rdfTypes.add(new URI(CmConstants.TYPE_CHANGE_REQUEST));
+    }
+
+    public ChangeRequest(final URI about)
+           throws URISyntaxException
+    {
+        super(about);
+
+        rdfTypes.add(new URI(CmConstants.TYPE_CHANGE_REQUEST));
+    }
+
+    public void addAffectedByDefect(final Link affectedByDefect)
+    {
+        this.affectedByDefects.add(affectedByDefect);
+    }
+
+    public void addAffectsPlanItem(final Link affectsPlanItem)
+    {
+        this.affectsPlanItems.add(affectsPlanItem);
+    }
+
+    public void addAffectsRequirement(final Link affectsRequirement)
+    {
+        this.affectsRequirements.add(affectsRequirement);
+    }
+
+    public void addAffectsTestResult(final Link affectsTestResult)
+    {
+        this.affectsTestResults.add(affectsTestResult);
+    }
+
+    public void addBlocksTestExecutionRecord(final Link blocksTestExecutionRecord)
+    {
+        this.blocksTestExecutionRecords.add(blocksTestExecutionRecord);
+    }
+
+    public void addContributor(final URI contributor)
+    {
+        this.contributors.add(contributor);
+    }
+
+    public void addCreator(final URI creator)
+    {
+        this.creators.add(creator);
+    }
+
+    public void addDctermsType(final String dctermsType)
+    {
+        this.dctermsTypes.add(dctermsType);
+    }
+
+    public void addImplementsRequirement(final Link implementsRequirement)
+    {
+        this.implementsRequirements.add(implementsRequirement);
+    }
+
+    public void addRdfType(final URI rdfType)
+    {
+        this.rdfTypes.add(rdfType);
+    }
+
+    public void addRelatedChangeRequest(final Link relatedChangeRequest)
+    {
+        this.relatedChangeRequests.add(relatedChangeRequest);
+    }
+
+    public void addRelatedResource(final Link relatedResource)
+    {
+        this.relatedResources.add(relatedResource);
+    }
+
+    public void addRelatedTestCase(final Link relatedTestCase)
+    {
+        this.relatedTestCases.add(relatedTestCase);
+    }
+
+    public void addRelatedTestExecutionRecord(final Link relatedTestExecutionRecord)
+    {
+        this.relatedTestExecutionRecords.add(relatedTestExecutionRecord);
+    }
+
+    public void addRelatedTestPlan(final Link relatedTestPlan)
+    {
+        this.relatedTestPlans.add(relatedTestPlan);
+    }
+
+    public void addRelatedTestScript(final Link relatedTestScript)
+    {
+        this.relatedTestScripts.add(relatedTestScript);
+    }
+
+    public void addSubject(final String subject)
+    {
+        this.subjects.add(subject);
+    }
+
+    public void addTestedByTestCase(final Link testedByTestCase)
+    {
+        this.testedByTestCases.add(testedByTestCase);
+    }
+
+    public void addTracksChangeSet(final Link tracksChangeSet)
+    {
+        this.tracksChangeSets.add(tracksChangeSet);
+    }
+
+    public void addTracksRequirement(final Link tracksRequirement)
+    {
+        this.tracksRequirements.add(tracksRequirement);
+    }
+
+    @OslcDescription("Change request is affected by a reported defect.")
+    @OslcName("affectedByDefect")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "affectedByDefect")
+    @OslcRange(CmConstants.TYPE_CHANGE_REQUEST)
+    @OslcReadOnly(false)
+    @OslcTitle("Affected By Defects")
+    public Link[] getAffectedByDefects()
+    {
+        return affectedByDefects.toArray(new Link[affectedByDefects.size()]);
+    }
+
+    @OslcDescription("Change request affects a plan item. ")
+    @OslcName("affectsPlanItem")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "affectsPlanItem")
+    @OslcRange(CmConstants.TYPE_CHANGE_REQUEST)
+    @OslcReadOnly(false)
+    @OslcTitle("Affects Plan Items")
+    public Link[] getAffectsPlanItems()
+    {
+        return affectsPlanItems.toArray(new Link[affectsPlanItems.size()]);
+    }
+
+    @OslcDescription("Change request affecting a Requirement.")
+    @OslcName("affectsRequirement")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "affectsRequirement")
+    @OslcRange(CmConstants.TYPE_REQUIREMENT)
+    @OslcReadOnly(false)
+    @OslcTitle("Affects Requirements")
+    public Link[] getAffectsRequirements()
+    {
+        return affectsRequirements.toArray(new Link[affectsRequirements.size()]);
+    }
+
+    @OslcDescription("Associated QM resource that is affected by this Change Request.")
+    @OslcName("affectsTestResult")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "affectsTestResult")
+    @OslcRange(CmConstants.TYPE_TEST_RESULT)
+    @OslcReadOnly(false)
+    @OslcTitle("Affects Test Results")
+    public Link[] getAffectsTestResults()
+    {
+        return affectsTestResults.toArray(new Link[affectsTestResults.size()]);
+    }
+
+    @OslcDescription("Associated QM resource that is blocked by this Change Request.")
+    @OslcName("blocksTestExecutionRecord")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "blocksTestExecutionRecord")
+    @OslcRange(CmConstants.TYPE_TEST_EXECUTION_RECORD)
+    @OslcReadOnly(false)
+    @OslcTitle("Blocks Test Execution Records")
+    public Link[] getBlocksTestExecutionRecords()
+    {
+        return blocksTestExecutionRecords.toArray(new Link[blocksTestExecutionRecords.size()]);
+    }
+
+    @OslcDescription("The date at which no further activity or work is intended to be conducted. ")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "closeDate")
+    @OslcReadOnly
+    @OslcTitle("Close Date")
+    public Date getCloseDate()
+    {
+        return closeDate;
+    }
+
+    @OslcDescription("The person(s) who are responsible for the work needed to complete the change request.")
+    @OslcName("contributor")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "contributor")
+    @OslcRange(CmConstants.TYPE_PERSON)
+    @OslcTitle("Contributors")
+    public URI[] getContributors()
+    {
+        return contributors.toArray(new URI[contributors.size()]);
+    }
+
+    @OslcDescription("Timestamp of resource creation.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "created")
+    @OslcReadOnly
+    @OslcTitle("Created")
+    public Date getCreated()
+    {
+        return created;
+    }
+
+    @OslcDescription("Creator or creators of resource.")
+    @OslcName("creator")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "creator")
+    @OslcRange(CmConstants.TYPE_PERSON)
+    @OslcTitle("Creators")
+    public URI[] getCreators()
+    {
+        return creators.toArray(new URI[creators.size()]);
+    }
+
+    @OslcAllowedValue({"Defect", "Task", "Story", "Bug Report", "Feature Request"})
+    @OslcDescription("A short string representation for the type, example 'Defect'.")
+    @OslcName("type")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "type")
+    @OslcTitle("Types")
+    public String[] getDctermsTypes()
+    {
+        return dctermsTypes.toArray(new String[dctermsTypes.size()]);
+    }
+
+    @OslcDescription("Descriptive text (reference: Dublin Core) about resource represented as rich text in XHTML content.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "description")
+    @OslcTitle("Description")
+    @OslcValueType(ValueType.XMLLiteral)
+    public String getDescription()
+    {
+        return description;
+    }
+
+    @OslcDescription("A series of notes and comments about this change request.")
+    @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "discussedBy")
+    @OslcRange(CmConstants.TYPE_DISCUSSION)
+    @OslcTitle("Discussed By")
+    public URI getDiscussedBy()
+    {
+        return discussedBy;
+    }
+
+    @OslcDescription("A unique identifier for a resource. Assigned by the service provider when a resource is created. Not intended for end-user display.")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "identifier")
+    @OslcReadOnly
+    @OslcTitle("Identifier")
+    public String getIdentifier()
+    {
+        return identifier;
+    }
+
+    @OslcDescription("Implements associated Requirement.")
+    @OslcName("implementsRequirement")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "implementsRequirement")
+    @OslcRange(CmConstants.TYPE_REQUIREMENT)
+    @OslcReadOnly(false)
+    @OslcTitle("Implements Requirements")
+    public Link[] getImplementsRequirements()
+    {
+        return implementsRequirements.toArray(new Link[implementsRequirements.size()]);
+    }
+
+    @OslcDescription("Resource Shape that provides hints as to resource property value-types and allowed values. ")
+    @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "instanceShape")
+    @OslcRange(OslcConstants.TYPE_RESOURCE_SHAPE)
+    @OslcTitle("Instance Shape")
+    public URI getInstanceShape()
+    {
+        return instanceShape;
+    }
+
+    @OslcDescription("Timestamp last latest resource modification.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "modified")
+    @OslcReadOnly
+    @OslcTitle("Modified")
+    public Date getModified()
+    {
+        return modified;
+    }
+
+    @OslcDescription("The resource type URIs.")
+    @OslcName("type")
+    @OslcPropertyDefinition(OslcConstants.RDF_NAMESPACE + "type")
+    @OslcTitle("Types")
+    public URI[] getRdfTypes()
+    {
+        return rdfTypes.toArray(new URI[rdfTypes.size()]);
+    }
+
+    @OslcDescription("This relationship is loosely coupled and has no specific meaning.")
+    @OslcName("relatedChangeRequest")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "relatedChangeRequest")
+    @OslcRange(CmConstants.TYPE_CHANGE_REQUEST)
+    @OslcReadOnly(false)
+    @OslcTitle("Related Change Requests")
+    public Link[] getRelatedChangeRequests()
+    {
+        return relatedChangeRequests.toArray(new Link[relatedChangeRequests.size()]);
+    }
+
+    @OslcDescription("Related OSLC resources of any type.")
+    @OslcName("relatedResource")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "relatedResource")
+    @OslcTitle("Related Resources")
+    public Link[] getRelatedResources()
+    {
+        return relatedResources.toArray(new Link[relatedResources.size()]);
+    }
+
+    @OslcDescription("Related QM test case resource.")
+    @OslcName("relatedTestCase")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "relatedTestCase")
+    @OslcRange(CmConstants.TYPE_TEST_CASE)
+    @OslcReadOnly(false)
+    @OslcTitle("Related Test Cases")
+    public Link[] getRelatedTestCases()
+    {
+        return relatedTestCases.toArray(new Link[relatedTestCases.size()]);
+    }
+
+    @OslcDescription("Related to a QM test execution resource.")
+    @OslcName("relatedTestExecutionRecord")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "relatedTestExecutionRecord")
+    @OslcRange(CmConstants.TYPE_TEST_EXECUTION_RECORD)
+    @OslcReadOnly(false)
+    @OslcTitle("Related Test Execution Records")
+    public Link[] getRelatedTestExecutionRecords()
+    {
+        return relatedTestExecutionRecords.toArray(new Link[relatedTestExecutionRecords.size()]);
+    }
+
+    @OslcDescription("Related QM test plan resource.")
+    @OslcName("relatedTestPlan")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "relatedTestPlan")
+    @OslcRange(CmConstants.TYPE_TEST_PLAN)
+    @OslcReadOnly(false)
+    @OslcTitle("Related Test Plans")
+    public Link[] getRelatedTestPlans()
+    {
+        return relatedTestPlans.toArray(new Link[relatedTestPlans.size()]);
+    }
+
+    @OslcDescription("Related QM test script resource.")
+    @OslcName("relatedTestScript")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "relatedTestScript")
+    @OslcRange(CmConstants.TYPE_TEST_SCRIPT)
+    @OslcReadOnly(false)
+    @OslcTitle("Related Test Scripts")
+    public Link[] getRelatedTestScripts()
+    {
+        return relatedTestScripts.toArray(new Link[relatedTestScripts.size()]);
+    }
+
+    @OslcDescription("The scope of a resource is a URI for the resource's OSLC Service Provider.")
+    @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "serviceProvider")
+    @OslcRange(OslcConstants.TYPE_SERVICE_PROVIDER)
+    @OslcTitle("Service Provider")
+    public URI getServiceProvider()
+    {
+        return serviceProvider;
+    }
+
+    @OslcDescription("Short name identifying a resource, often used as an abbreviated identifier for presentation to end-users.")
+    @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "shortTitle")
+    @OslcTitle("Short Title")
+    @OslcValueType(ValueType.XMLLiteral)
+    public String getShortTitle()
+    {
+        return shortTitle;
+    }
+
+    @OslcDescription("Used to indicate the status of the change request based on values defined by the service provider. Most often a read-only property. Some possible values may include: 'Submitted', 'Done', 'InProgress', etc.")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "status")
+    @OslcTitle("Status")
+    public String getStatus()
+    {
+        return status;
+    }
+
+    @OslcDescription("Tag or keyword for a resource. Each occurrence of a dcterms:subject property denotes an additional tag for the resource.")
+    @OslcName("subject")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "subject")
+    @OslcReadOnly(false)
+    @OslcTitle("Subjects")
+    public String[] getSubjects()
+    {
+        return subjects.toArray(new String[subjects.size()]);
+    }
+
+    @OslcDescription("Test case by which this change request is tested.")
+    @OslcName("testedByTestCase")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "testedByTestCase")
+    @OslcRange(CmConstants.TYPE_TEST_CASE)
+    @OslcReadOnly(false)
+    @OslcTitle("Tested by Test Cases")
+    public Link[] getTestedByTestCases()
+    {
+        return testedByTestCases.toArray(new Link[testedByTestCases.size()]);
+    }
+
+    @OslcDescription("Title (reference: Dublin Core) or often a single line summary of the resource represented as rich text in XHTML content.")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "title")
+    @OslcTitle("Title")
+    @OslcValueType(ValueType.XMLLiteral)
+    public String getTitle()
+    {
+        return title;
+    }
+
+    @OslcDescription("Tracks SCM change set resource.")
+    @OslcName("tracksChangeSet")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "tracksChangeSet")
+    @OslcRange(CmConstants.TYPE_CHANGE_SET)
+    @OslcReadOnly(false)
+    @OslcTitle("Tracks Change Sets")
+    public Link[] getTracksChangeSets()
+    {
+        return tracksChangeSets.toArray(new Link[tracksChangeSets.size()]);
+    }
+
+    @OslcDescription("Tracks the associated Requirement or Requirement ChangeSet resources.")
+    @OslcName("tracksRequirement")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "tracksRequirement")
+    @OslcRange(CmConstants.TYPE_REQUIREMENT)
+    @OslcReadOnly(false)
+    @OslcTitle("Tracks Requirements")
+    public Link[] getTracksRequirements()
+    {
+        return tracksRequirements.toArray(new Link[tracksRequirements.size()]);
+    }
+
+    @OslcDescription("Whether or not the Change Request has been approved.")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "approved")
+    @OslcReadOnly
+    @OslcTitle("Approved")
+    public Boolean isApproved()
+    {
+        return approved;
+    }
+
+    @OslcDescription("Whether or not the Change Request is completely done, no further fixes or fix verification is needed.")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "closed")
+    @OslcReadOnly
+    @OslcTitle("Closed")
+    public Boolean isClosed()
+    {
+        return closed;
+    }
+
+    @OslcDescription("Whether or not the Change Request has been fixed.")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "fixed")
+    @OslcReadOnly
+    @OslcTitle("Fixed")
+    public Boolean isFixed()
+    {
+        return fixed;
+    }
+
+    @OslcDescription("Whether or not the Change Request in a state indicating that active work is occurring. If oslc_cm:inprogress is true, then oslc_cm:fixed and oslc_cm:closed must also be false.")
+    @OslcName("inprogress")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "inprogress")
+    @OslcReadOnly
+    @OslcTitle("In Progress")
+    public Boolean isInProgress()
+    {
+        return inProgress;
+    }
+
+    @OslcDescription("Whether or not the Change Request has been reviewed.")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "reviewed")
+    @OslcReadOnly
+    @OslcTitle("Reviewed")
+    public Boolean isReviewed()
+    {
+        return reviewed;
+    }
+
+    @OslcDescription("Whether or not the resolution or fix of the Change Request has been verified.")
+    @OslcPropertyDefinition(CmConstants.CHANGE_MANAGEMENT_NAMESPACE + "verified")
+    @OslcReadOnly
+    @OslcTitle("Verified")
+    public Boolean isVerified()
+    {
+        return verified;
+    }
+
+    public void setAffectedByDefects(final Link[] affectedByDefects)
+    {
+        this.affectedByDefects.clear();
+
+        if (affectedByDefects != null)
+        {
+            this.affectedByDefects.addAll(Arrays.asList(affectedByDefects));
+        }
+    }
+
+    public void setAffectsPlanItems(final Link[] affectsPlanItems)
+    {
+        this.affectsPlanItems.clear();
+
+        if (affectsPlanItems != null)
+        {
+            this.affectsPlanItems.addAll(Arrays.asList(affectsPlanItems));
+        }
+    }
+
+    public void setAffectsRequirements(final Link[] affectsRequirements)
+    {
+        this.affectsRequirements.clear();
+
+        if (affectsRequirements != null)
+        {
+            this.affectsRequirements.addAll(Arrays.asList(affectsRequirements));
+        }
+    }
+
+    public void setAffectsTestResults(final Link[] affectsTestResults)
+    {
+        this.affectsTestResults.clear();
+
+        if (affectsTestResults != null)
+        {
+            this.affectsTestResults.addAll(Arrays.asList(affectsTestResults));
+        }
+    }
+
+    public void setApproved(final Boolean approved)
+    {
+        this.approved = approved;
+    }
+
+    public void setBlocksTestExecutionRecords(final Link[] blocksTestExecutionRecords)
+    {
+        this.blocksTestExecutionRecords.clear();
+
+        if (blocksTestExecutionRecords != null)
+        {
+            this.blocksTestExecutionRecords.addAll(Arrays.asList(blocksTestExecutionRecords));
+        }
+    }
+
+    public void setClosed(final Boolean closed)
+    {
+        this.closed = closed;
+    }
+
+    public void setCloseDate(final Date closeDate)
+    {
+        this.closeDate = closeDate;
+    }
+
+    public void setContributors(final URI[] contributors)
+    {
+        this.contributors.clear();
+
+        if (contributors != null)
+        {
+            this.contributors.addAll(Arrays.asList(contributors));
+        }
+    }
+
+    public void setCreated(final Date created)
+    {
+        this.created = created;
+    }
+
+    public void setCreators(final URI[] creators)
+    {
+        this.creators.clear();
+
+        if (creators != null)
+        {
+            this.creators.addAll(Arrays.asList(creators));
+        }
+    }
+
+    public void setDctermsTypes(final String[] dctermsTypes)
+    {
+        this.dctermsTypes.clear();
+
+        if (dctermsTypes != null)
+        {
+        	this.dctermsTypes.addAll(Arrays.asList(dctermsTypes));
+        }
+    }
+
+    public void setDescription(final String description)
+    {
+        this.description = description;
+    }
+
+    public void setDiscussedBy(final URI discussedBy)
+    {
+        this.discussedBy = discussedBy;
+    }
+
+    public void setFixed(final Boolean fixed)
+    {
+        this.fixed = fixed;
+    }
+
+    public void setIdentifier(final String identifier)
+    {
+        this.identifier = identifier;
+    }
+
+    public void setImplementsRequirements(final Link[] implementsRequirements)
+    {
+        this.implementsRequirements.clear();
+
+        if (implementsRequirements != null)
+        {
+            this.implementsRequirements.addAll(Arrays.asList(implementsRequirements));
+        }
+    }
+
+    public void setInProgress(final Boolean inProgress)
+    {
+        this.inProgress = inProgress;
+    }
+
+    public void setInstanceShape(final URI instanceShape)
+    {
+        this.instanceShape = instanceShape;
+    }
+
+    public void setModified(final Date modified)
+    {
+        this.modified = modified;
+    }
+
+    public void setRdfTypes(final URI[] rdfTypes)
+    {
+        this.rdfTypes.clear();
+
+        if (rdfTypes != null)
+        {
+            this.rdfTypes.addAll(Arrays.asList(rdfTypes));
+        }
+    }
+
+    public void setRelatedChangeRequests(final Link[] relatedChangeRequests)
+    {
+        this.relatedChangeRequests.clear();
+
+        if (relatedChangeRequests != null)
+        {
+            this.relatedChangeRequests.addAll(Arrays.asList(relatedChangeRequests));
+        }
+    }
+
+    public void setRelatedResources(final Link[] relatedResources)
+    {
+        this.relatedResources.clear();
+
+        if (relatedResources != null)
+        {
+            this.relatedResources.addAll(Arrays.asList(relatedResources));
+        }
+    }
+
+    public void setRelatedTestCases(final Link[] relatedTestCases)
+    {
+        this.relatedTestCases.clear();
+
+        if (relatedTestCases != null)
+        {
+            this.relatedTestCases.addAll(Arrays.asList(relatedTestCases));
+        }
+    }
+
+    public void setRelatedTestExecutionRecords(final Link[] relatedTestExecutionRecords)
+    {
+        this.relatedTestExecutionRecords.clear();
+
+        if (relatedTestExecutionRecords != null)
+        {
+            this.relatedTestExecutionRecords.addAll(Arrays.asList(relatedTestExecutionRecords));
+        }
+    }
+
+    public void setRelatedTestPlans(final Link[] relatedTestPlans)
+    {
+        this.relatedTestPlans.clear();
+
+        if (relatedTestPlans != null)
+        {
+            this.relatedTestPlans.addAll(Arrays.asList(relatedTestPlans));
+        }
+    }
+
+    public void setRelatedTestScripts(final Link[] relatedTestScripts)
+    {
+        this.relatedTestScripts.clear();
+
+        if (relatedTestScripts != null)
+        {
+            this.relatedTestScripts.addAll(Arrays.asList(relatedTestScripts));
+        }
+    }
+
+    public void setReviewed(final Boolean reviewed)
+    {
+        this.reviewed = reviewed;
+    }
+
+    public void setServiceProvider(final URI serviceProvider)
+    {
+        this.serviceProvider = serviceProvider;
+    }
+
+    public void setShortTitle(final String shortTitle)
+    {
+        this.shortTitle = shortTitle;
+    }
+
+    public void setStatus(final String status)
+    {
+        this.status = status;
+    }
+
+    public void setSubjects(final String[] subjects)
+    {
+        this.subjects.clear();
+
+        if (subjects != null)
+        {
+            this.subjects.addAll(Arrays.asList(subjects));
+        }
+    }
+
+    public void setTestedByTestCases(final Link[] testedByTestCases)
+    {
+        this.testedByTestCases.clear();
+
+        if (testedByTestCases != null)
+        {
+            this.testedByTestCases.addAll(Arrays.asList(testedByTestCases));
+        }
+    }
+
+    public void setTitle(final String title)
+    {
+        this.title = title;
+    }
+
+    public void setTracksChangeSets(final Link[] tracksChangeSets)
+    {
+        this.tracksChangeSets.clear();
+
+        if (tracksChangeSets != null)
+        {
+            this.tracksChangeSets.addAll(Arrays.asList(tracksChangeSets));
+        }
+    }
+
+    public void setTracksRequirements(final Link[] tracksRequirements)
+    {
+        this.tracksRequirements.clear();
+
+        if (tracksRequirements != null)
+        {
+            this.tracksRequirements.addAll(Arrays.asList(tracksRequirements));
+        }
+    }
+
+    public void setVerified(final Boolean verified)
+    {
+        this.verified = verified;
+    }
+}

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/CmConstants.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/CmConstants.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2012 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *     Russell Boykin       - initial API and implementation
+ *     Alberto Giammaria    - initial API and implementation
+ *     Chris Peters         - initial API and implementation
+ *     Gianluca Bernardini  - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
+
+public interface CmConstants
+{
+    public static String CHANGE_MANAGEMENT_DOMAIN                    = "http://open-services.net/ns/cm#";
+    public static String CHANGE_MANAGEMENT_NAMESPACE                 = "http://open-services.net/ns/cm#";
+    public static String CHANGE_MANAGEMENT_NAMESPACE_PREFIX          = "oslc_cm";
+    public static String FOAF_NAMESPACE                              = "http://xmlns.com/foaf/0.1/";
+    public static String FOAF_NAMESPACE_PREFIX                       = "foaf";
+    public static String QUALITY_MANAGEMENT_NAMESPACE                = "http://open-services.net/ns/qm#";
+    public static String QUALITY_MANAGEMENT_PREFIX                   = "oslc_qm";
+    public static String REQUIREMENTS_MANAGEMENT_NAMESPACE           = "http://open-services.net/ns/rm#";
+    public static String REQUIREMENTS_MANAGEMENT_PREFIX              = "oslc_rm";
+    public static String SOFTWARE_CONFIGURATION_MANAGEMENT_NAMESPACE = "http://open-services.net/ns/scm#";
+    public static String SOFTWARE_CONFIGURATION_MANAGEMENT_PREFIX    = "oslc_scm";
+
+
+    public static String TYPE_CHANGE_REQUEST        = CHANGE_MANAGEMENT_NAMESPACE + "ChangeRequest";
+    public static String TYPE_CHANGE_SET            = SOFTWARE_CONFIGURATION_MANAGEMENT_NAMESPACE + "ChangeSet";
+    public static String TYPE_DISCUSSION            = OslcConstants.OSLC_CORE_NAMESPACE + "Discussion";
+    public static String TYPE_PERSON                = FOAF_NAMESPACE + "Person";
+    public static String TYPE_REQUIREMENT           = REQUIREMENTS_MANAGEMENT_NAMESPACE + "Requirement";
+    public static String TYPE_TEST_CASE             = QUALITY_MANAGEMENT_NAMESPACE + "TestCase";
+    public static String TYPE_TEST_EXECUTION_RECORD = QUALITY_MANAGEMENT_NAMESPACE + "TestExecutionRecord";
+    public static String TYPE_TEST_PLAN             = QUALITY_MANAGEMENT_NAMESPACE + "TestPlan";
+    public static String TYPE_TEST_RESULT           = QUALITY_MANAGEMENT_NAMESPACE + "TestResult";
+    public static String TYPE_TEST_SCRIPT           = QUALITY_MANAGEMENT_NAMESPACE + "TestScript";
+
+    public static String PATH_CHANGE_REQUEST = "changeRequest";
+
+    public static String USAGE_LIST = CHANGE_MANAGEMENT_NAMESPACE + "list";
+}

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/ParameterInstance.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/ParameterInstance.java
@@ -1,0 +1,169 @@
+/*******************************************************************************
+ * Copyright (c) 2012 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *     Paul McMahan <pmcmahan@us.ibm.com>        - initial implementation
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcOccurs;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcRange;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
+import org.eclipse.lyo.oslc4j.core.model.Occurs;
+import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
+import org.eclipse.lyo.oslc4j.core.model.ValueType;
+
+@OslcResourceShape(title = "Parameter Instance Resource Shape", describes = AutomationConstants.TYPE_PARAMETER_INSTANCE)
+@OslcNamespace(AutomationConstants.AUTOMATION_NAMESPACE)
+/**
+ * @see http://open-services.net/wiki/automation/OSLC-Automation-Specification-Version-2.0/#Resource_ParameterInstance
+ */
+public final class ParameterInstance
+extends AbstractResource implements Comparable<ParameterInstance>
+{
+    private final Set<URI>      rdfTypes                    = new TreeSet<URI>();
+
+    private String   name;
+    private String   value;
+    private String   description;
+    private URI      instanceShape;
+    private URI      serviceProvider;
+
+	public ParameterInstance()
+	{
+		super();
+
+		rdfTypes.add(URI.create(AutomationConstants.TYPE_PARAMETER_INSTANCE));
+	}
+
+    public ParameterInstance(final URI about)
+    {
+         super(about);
+
+		rdfTypes.add(URI.create(AutomationConstants.TYPE_PARAMETER_INSTANCE));
+     }
+
+    protected URI getRdfType() {
+    	return URI.create(AutomationConstants.TYPE_PARAMETER_INSTANCE);
+    }
+
+    public void addRdfType(final URI rdfType)
+    {
+        this.rdfTypes.add(rdfType);
+    }
+
+    @OslcDescription("Descriptive text (reference: Dublin Core) about resource represented as rich text in XHTML content.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "description")
+    @OslcTitle("Description")
+    @OslcValueType(ValueType.XMLLiteral)
+    public String getDescription()
+    {
+        return description;
+    }
+
+    @OslcDescription("The name of the parameter instance.")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "name")
+    @OslcTitle("Name")
+    public String getName()
+    {
+        return name;
+    }
+
+    @OslcDescription("The value of the parameter.")
+    @OslcOccurs(Occurs.ZeroOrOne)
+    @OslcPropertyDefinition(OslcConstants.RDF_NAMESPACE + "value")
+    @OslcTitle("Value")
+    public String getValue()
+    {
+        return value;
+    }
+
+    @OslcDescription("Resource Shape that provides hints as to resource property value-types and allowed values. ")
+    @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "instanceShape")
+    @OslcRange(OslcConstants.TYPE_RESOURCE_SHAPE)
+    @OslcTitle("Instance Shape")
+    public URI getInstanceShape()
+    {
+        return instanceShape;
+    }
+
+    @OslcDescription("The resource type URIs.")
+    @OslcName("type")
+    @OslcPropertyDefinition(OslcConstants.RDF_NAMESPACE + "type")
+    @OslcTitle("Types")
+    public URI[] getRdfTypes()
+    {
+        return rdfTypes.toArray(new URI[rdfTypes.size()]);
+    }
+
+    @OslcDescription("The scope of a resource is a URI for the resource's OSLC Service Provider.")
+    @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "serviceProvider")
+    @OslcRange(OslcConstants.TYPE_SERVICE_PROVIDER)
+    @OslcTitle("Service Provider")
+    public URI getServiceProvider()
+    {
+        return serviceProvider;
+    }
+
+    public void setDescription(final String description)
+    {
+        this.description = description;
+    }
+
+    public void setName(final String name)
+    {
+        this.name = name;
+    }
+
+    public void setValue(final String value)
+    {
+        this.value = value;
+    }
+
+    public void setInstanceShape(final URI instanceShape)
+    {
+        this.instanceShape = instanceShape;
+    }
+
+    public void setRdfTypes(final URI[] rdfTypes)
+    {
+        this.rdfTypes.clear();
+
+        if (rdfTypes != null)
+        {
+            this.rdfTypes.addAll(Arrays.asList(rdfTypes));
+        }
+    }
+
+    public void setServiceProvider(final URI serviceProvider)
+    {
+        this.serviceProvider = serviceProvider;
+    }
+
+	public int compareTo(ParameterInstance o) {
+		return o.getName().compareTo(name);
+	}
+
+}

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/ParameterInstance.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/ParameterInstance.java
@@ -34,6 +34,10 @@ import org.eclipse.lyo.oslc4j.core.model.Occurs;
 import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
 import org.eclipse.lyo.oslc4j.core.model.ValueType;
 
+/**
+ * @see org.eclipse.lyo.oslc.domains.auto.ParameterInstance
+ */
+@Deprecated
 @OslcResourceShape(title = "Parameter Instance Resource Shape", describes = AutomationConstants.TYPE_PARAMETER_INSTANCE)
 @OslcNamespace(AutomationConstants.AUTOMATION_NAMESPACE)
 /**

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/Property.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/Property.java
@@ -1,0 +1,427 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2014 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *     Russell Boykin       - initial API and implementation
+ *     Alberto Giammaria    - initial API and implementation
+ *     Chris Peters         - initial API and implementation
+ *     Gianluca Bernardini  - initial API and implementation
+ *     Samuel Padgett       - support allowed and default values other than string
+ *     Samuel Padgett       - copy from lyo.core and modify specifically for automation plans
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import javax.xml.namespace.QName;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcAllowedValue;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcOccurs;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcRange;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcReadOnly;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcValueShape;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
+import org.eclipse.lyo.oslc4j.core.model.Occurs;
+import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
+import org.eclipse.lyo.oslc4j.core.model.Representation;
+import org.eclipse.lyo.oslc4j.core.model.ValueType;
+
+/**
+ * Identical to {@link org.eclipse.lyo.oslc4j.core.model.Property}, except that
+ * it does not have an oslc:propertyDefinition field. This class is intended to
+ * only be used for OSLC automation plans.
+ */
+@OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)
+@OslcResourceShape(title = "OSLC Property Resource Shape", describes = OslcConstants.TYPE_PROPERTY)
+public final class Property extends AbstractResource implements Comparable<Property> {
+	private static final QName PROPERTY_ALLOWED_VALUE = new QName(OslcConstants.OSLC_CORE_NAMESPACE, "allowedValue");
+	private static final QName PROPERTY_DEFAULT_VALUE = new QName(OslcConstants.OSLC_CORE_NAMESPACE, "defaultValue");
+	private final List<URI> range = new ArrayList<URI>();
+
+    private URI allowedValuesRef;
+	private String description;
+	private Boolean hidden;
+	private Integer maxSize;
+	private Boolean memberProperty;
+	private String name;
+	private Occurs occurs;
+	private Boolean readOnly;
+	private Representation representation;
+	private String title;
+	private URI valueShape;
+	private ValueType valueType;
+
+	public Property() {
+	    super();
+	}
+
+	public Property(final String name,
+			final Occurs occurs,
+			final ValueType valueType) {
+		this();
+
+		this.name = name;
+		this.occurs = occurs;
+		this.valueType = valueType;
+	}
+
+	public void addRange(final URI range) {
+		this.range.add(range);
+	}
+
+	@Override
+	public int compareTo(final Property o) {
+		return name.compareTo(o.getName());
+	}
+
+	@OslcDescription("Resource with allowed values for the property being defined")
+	@OslcName("allowedValues")
+	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "allowedValues")
+	@OslcRange(OslcConstants.TYPE_ALLOWED_VALUES)
+	@OslcReadOnly
+    @OslcTitle("Allowed Value Reference")
+	@OslcValueShape(OslcConstants.PATH_RESOURCE_SHAPES + "/" + OslcConstants.PATH_ALLOWED_VALUES)
+	public URI getAllowedValuesRef() {
+	    return allowedValuesRef;
+	}
+
+	public Object getDefaultValueObject() {
+		return getExtendedProperties().get(PROPERTY_DEFAULT_VALUE);
+	}
+
+	/**
+	 * @deprecated Use {@link #getDefaultValueObject()}, which supports types other than String
+	 */
+	@Deprecated
+	public String getDefaultValue() {
+		Object o = getExtendedProperties().get(PROPERTY_DEFAULT_VALUE);
+
+		// Backwards compatibility: Only return a value if it's a string.
+		return (o instanceof String) ? (String) o : null;
+	}
+
+	@OslcDescription("Description of the property. SHOULD include only content that is valid and suitable inside an XHTML <div> element")
+	@OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "description")
+	@OslcReadOnly
+    @OslcTitle("Description")
+    @OslcValueType(ValueType.XMLLiteral)
+	public String getDescription() {
+		return description;
+	}
+
+	@OslcDescription("For String properties only, specifies maximum characters allowed. If not set, then there is no maximum or maximum is specified elsewhere")
+	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "maxSize")
+	@OslcReadOnly
+    @OslcTitle("Maximum Size")
+	public Integer getMaxSize() {
+		return maxSize;
+	}
+
+	@OslcDescription("Name of property being defined, i.e. second part of property's Prefixed Name")
+	@OslcOccurs(Occurs.ExactlyOne)
+	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "name")
+	@OslcReadOnly
+	@OslcTitle("Name")
+    public String getName() {
+		return name;
+	}
+
+	@OslcAllowedValue({OslcConstants.OSLC_CORE_NAMESPACE + "Exactly-one",
+                       OslcConstants.OSLC_CORE_NAMESPACE + "Zero-or-one",
+                       OslcConstants.OSLC_CORE_NAMESPACE + "Zero-or-many",
+                       OslcConstants.OSLC_CORE_NAMESPACE + "One-or-many"})
+	@OslcDescription("MUST be either http://open-services.net/ns/core#Exactly-one, http://open-services.net/ns/core#Zero-or-one, http://open-services.net/ns/core#Zero-or-many or http://open-services.net/ns/core#One-or-many")
+	@OslcOccurs(Occurs.ExactlyOne)
+	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "occurs")
+	@OslcReadOnly
+    @OslcTitle("Occurs")
+	public URI getOccurs() {
+	    if (occurs != null) {
+	        try {
+	            return new URI(occurs.toString());
+	        } catch (final URISyntaxException exception) {
+	            // This should never happen since we control the possible values of the Occurs enum.
+	            throw new RuntimeException(exception);
+	        }
+	    }
+
+	    return null;
+	}
+
+	@OslcDescription("For properties with a resource value-type, Providers MAY also specify the range of possible resource classes allowed, each specified by URI. The default range is http://open-services.net/ns/core#Any")
+	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "range")
+	@OslcReadOnly
+    @OslcTitle("Ranges")
+	public URI[] getRange() {
+	    return range.toArray(new URI[range.size()]);
+	}
+
+	@OslcAllowedValue({OslcConstants.OSLC_CORE_NAMESPACE + "Reference",
+	                   OslcConstants.OSLC_CORE_NAMESPACE + "Inline",
+	                   OslcConstants.OSLC_CORE_NAMESPACE + "Either"})
+    @OslcDescription("Should be http://open-services.net/ns/core#Reference, http://open-services.net/ns/core#Inline or http://open-services.net/ns/core#Either")
+	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "representation")
+	@OslcReadOnly
+    @OslcTitle("Representation")
+	public URI getRepresentation() {
+	    if (representation != null) {
+	        try {
+	            return new URI(representation.toString());
+	        } catch (final URISyntaxException exception) {
+	            // This should never happen since we control the possible values of the Representation enum.
+	            throw new RuntimeException(exception);
+	        }
+	    }
+
+	    return null;
+	}
+
+	@OslcDescription("Title of the property. SHOULD include only content that is valid and suitable inside an XHTML <div> element")
+	@OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "title")
+	@OslcReadOnly
+    @OslcTitle("Title")
+	@OslcValueType(ValueType.XMLLiteral)
+    public String getTitle() {
+		return title;
+	}
+
+	@OslcDescription("if the value-type is a resource type, then Property MAY provide a shape value to indicate the Resource Shape that applies to the resource")
+	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "valueShape")
+	@OslcRange(OslcConstants.TYPE_RESOURCE_SHAPE)
+	@OslcReadOnly
+    @OslcTitle("Value Shape")
+    public URI getValueShape() {
+	    return valueShape;
+	}
+
+	@OslcAllowedValue({OslcConstants.XML_NAMESPACE + "boolean",
+	                   OslcConstants.XML_NAMESPACE + "dateTime",
+	                   OslcConstants.XML_NAMESPACE + "decimal",
+	                   OslcConstants.XML_NAMESPACE + "double",
+	                   OslcConstants.XML_NAMESPACE + "float",
+	                   OslcConstants.XML_NAMESPACE + "integer",
+	                   OslcConstants.XML_NAMESPACE + "string",
+	                   OslcConstants.RDF_NAMESPACE + "XMLLiteral",
+	                   OslcConstants.OSLC_CORE_NAMESPACE + "Resource",
+	                   OslcConstants.OSLC_CORE_NAMESPACE + "LocalResource",
+	                   OslcConstants.OSLC_CORE_NAMESPACE + "AnyResource"})
+    @OslcDescription("See list of allowed values for oslc:valueType")
+    @OslcOccurs(Occurs.ExactlyOne)
+	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "valueType")
+	@OslcReadOnly
+    @OslcTitle("Value Type")
+	public URI getValueType() {
+	    if (valueType != null) {
+	        try {
+	            return new URI(valueType.toString());
+	        } catch (final URISyntaxException exception) {
+                // This should never happen since we control the possible values of the ValueType enum.
+                throw new RuntimeException(exception);
+            }
+	    }
+
+	    return null;
+	}
+
+	@OslcDescription("A hint that indicates that property MAY be hidden when presented in a user interface")
+	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "hidden")
+	@OslcReadOnly
+    @OslcTitle("Hidden")
+	public Boolean isHidden() {
+		return hidden;
+	}
+
+	@OslcDescription("If set to true, this indicates that the property is a membership property, as described in the Query Syntax Specification: Member List Patterns. This is useful when the resource whose shape is being defined is viewed as a container of other resources. For example, look at the last example in Appendix B's RDF/XML Representation Examples: Specifying the shape of a query result, where blog:comment is defined as a membership property and comment that matches the query is returned as value of that property.")
+	@OslcName("isMemberProperty")
+	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "isMemberProperty")
+	@OslcReadOnly
+    @OslcTitle("Is Member Property")
+	public Boolean isMemberProperty() {
+		return memberProperty;
+	}
+
+	@OslcDescription("true if the property is read-only. If not set, or set to false, then the property is writable. Providers SHOULD declare a property read-only when changes to the value of that property will not be accepted on PUT. Consumers should note that the converse does not apply: Providers MAY reject a change to the value of a writable property.")
+	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "readOnly")
+	@OslcReadOnly
+    @OslcTitle("Read Only")
+	public Boolean isReadOnly() {
+		return readOnly;
+	}
+
+	public void setAllowedValuesRef(final URI allowedValuesRef) {
+	    if (allowedValuesRef != null) {
+	        this.allowedValuesRef = allowedValuesRef;
+	    } else {
+	        this.allowedValuesRef = null;
+	    }
+	}
+
+	public void setDefaultValue(final Object defaultValue) {
+		if (defaultValue == null) {
+			getExtendedProperties().remove(PROPERTY_DEFAULT_VALUE);
+		} else {
+			getExtendedProperties().put(PROPERTY_DEFAULT_VALUE, defaultValue);
+		}
+	}
+
+	public void setDescription(final String description) {
+		this.description = description;
+	}
+
+	public void setHidden(final Boolean hidden) {
+		this.hidden = hidden;
+	}
+
+	public void setMaxSize(final Integer maxSize) {
+		this.maxSize = maxSize;
+	}
+
+	public void setMemberProperty(final Boolean memberProperty) {
+		this.memberProperty = memberProperty;
+	}
+
+	public void setName(final String name) {
+		this.name = name;
+	}
+
+	public void setOccurs(final Occurs occurs) {
+	    this.occurs = occurs;
+	}
+
+	public void setOccurs(final URI occurs) {
+	    if (occurs != null) {
+	        this.occurs = Occurs.fromString(occurs.toString());
+	    } else {
+	        this.occurs = null;
+	    }
+	}
+
+	public void setRange(final URI[] ranges) {
+	    this.range.clear();
+	    if (ranges != null) {
+	        this.range.addAll(Arrays.asList(ranges));
+	    }
+	}
+
+	public void setReadOnly(final Boolean readOnly) {
+		this.readOnly = readOnly;
+	}
+
+	public void setRepresentation(final Representation representation) {
+	    this.representation = representation;
+	}
+
+	public void setRepresentation(final URI representation) {
+	    if (representation != null) {
+	        this.representation = Representation.fromString(representation.toString());
+	    } else {
+	        this.representation = null;
+	    }
+	}
+
+	public void setTitle(final String title) {
+		this.title = title;
+	}
+
+	public void setValueShape(final URI valueShape) {
+	    this.valueShape = valueShape;
+	}
+
+	public void setValueType(final ValueType valueType) {
+	    this.valueType = valueType;
+	}
+
+	public void setValueType(final URI valueType) {
+	    if (valueType != null) {
+	        this.valueType = ValueType.fromString(valueType.toString());
+	    } else {
+	        this.valueType = null;
+	    }
+	}
+
+    public Collection<?> getAllowedValuesCollection() {
+        Collection<?> allowedValues = (Collection<?>) getExtendedProperties().get(PROPERTY_ALLOWED_VALUE);
+		if (allowedValues == null) {
+			return Collections.emptyList();
+		}
+
+		return allowedValues;
+	}
+
+	public void setAllowedValuesCollection(final Collection<?> values) {
+		if (values == null) {
+			getExtendedProperties().remove(PROPERTY_ALLOWED_VALUE);
+		} else {
+			getExtendedProperties().put(PROPERTY_ALLOWED_VALUE, values);
+		}
+	}
+
+	/**
+	 * @deprecated Use {@link #setAllowedValuesCollection(Collection)}, which allows for values other than String
+	 */
+	@Deprecated
+	public void addAllowedValue(final String allowedValue) {
+		ArrayList<Object> newValues = new ArrayList<Object>();
+		@SuppressWarnings("unchecked")
+        Collection<Object> allowedValues = (Collection<Object>) getExtendedProperties().get(PROPERTY_ALLOWED_VALUE);
+		if (allowedValues != null) {
+			newValues.addAll(allowedValues);
+		}
+
+		newValues.add(allowedValue);
+		setAllowedValuesCollection(newValues);
+	}
+
+	/**
+	 * @deprecated Use {@link #getAllowedValuesCollection()}, which allows for values other than String
+	 */
+	@Deprecated
+    public String[] getAllowedValues() {
+		// Be compatible with the old behavior and only include String values.
+		ArrayList<String> stringValues = new ArrayList<String>();
+		@SuppressWarnings("unchecked")
+        Collection<Object> values = (Collection<Object>) getExtendedProperties().get(PROPERTY_ALLOWED_VALUE);
+		if (values == null) {
+			return new String[]{};
+		}
+
+		for (Object o : values) {
+			if (o instanceof String) {
+				stringValues.add((String) o);
+			}
+		}
+
+		return stringValues.toArray(new String[stringValues.size()]);
+    }
+
+	/**
+	 * @deprecated Use {@link #setAllowedValuesCollection(Collection)}, which allows for values other than String
+	 */
+	@Deprecated
+	public void setAllowedValues(final String[] allowedValues) {
+		getExtendedProperties().put(PROPERTY_ALLOWED_VALUE, allowedValues);
+	}
+
+}

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/QmConstants.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/QmConstants.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2012 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *     Paul McMahan         - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
+
+public interface QmConstants
+{
+    public static String CHANGE_MANAGEMENT_DOMAIN                    = "http://open-services.net/ns/cm#";
+    public static String CHANGE_MANAGEMENT_NAMESPACE                 = "http://open-services.net/ns/cm#";
+    public static String CHANGE_MANAGEMENT_NAMESPACE_PREFIX          = "oslc_cm";
+    public static String FOAF_NAMESPACE                              = "http://xmlns.com/foaf/0.1/";
+    public static String FOAF_NAMESPACE_PREFIX                       = "foaf";
+    public static String QUALITY_MANAGEMENT_DOMAIN                    = "http://open-services.net/ns/qm#";
+    public static String QUALITY_MANAGEMENT_NAMESPACE                = "http://open-services.net/ns/qm#";
+    public static String QUALITY_MANAGEMENT_PREFIX                   = "oslc_qm";
+    public static String REQUIREMENTS_MANAGEMENT_NAMESPACE           = "http://open-services.net/ns/rm#";
+    public static String REQUIREMENTS_MANAGEMENT_PREFIX              = "oslc_rm";
+    public static String SOFTWARE_CONFIGURATION_MANAGEMENT_NAMESPACE = "http://open-services.net/ns/scm#";
+    public static String SOFTWARE_CONFIGURATION_MANAGEMENT_PREFIX    = "oslc_scm";
+
+
+    public static String TYPE_CHANGE_REQUEST        = CHANGE_MANAGEMENT_NAMESPACE + "ChangeRequest";
+    public static String TYPE_CHANGE_SET            = SOFTWARE_CONFIGURATION_MANAGEMENT_NAMESPACE + "ChangeSet";
+    public static String TYPE_DISCUSSION            = OslcConstants.OSLC_CORE_NAMESPACE + "Discussion";
+    public static String TYPE_PERSON                = FOAF_NAMESPACE + "Person";
+    public static String TYPE_REQUIREMENT           = REQUIREMENTS_MANAGEMENT_NAMESPACE + "Requirement";
+	public static String TYPE_REQUIREMENT_COLLECTION = REQUIREMENTS_MANAGEMENT_NAMESPACE + "RequirementCollection";
+    public static String TYPE_TEST_CASE             = QUALITY_MANAGEMENT_NAMESPACE + "TestCase";
+    public static String TYPE_TEST_EXECUTION_RECORD = QUALITY_MANAGEMENT_NAMESPACE + "TestExecutionRecord";
+    public static String TYPE_TEST_PLAN             = QUALITY_MANAGEMENT_NAMESPACE + "TestPlan";
+    public static String TYPE_TEST_RESULT           = QUALITY_MANAGEMENT_NAMESPACE + "TestResult";
+    public static String TYPE_TEST_SCRIPT           = QUALITY_MANAGEMENT_NAMESPACE + "TestScript";
+
+    public static String PATH_TEST_PLAN = "testPlan";
+    public static String PATH_TEST_CASE = "testCase";
+    public static String PATH_TEST_SCRIPT = "testScript";
+    public static String PATH_TEST_EXECUTION_RECORD = "testExecutionRecord";
+    public static String PATH_TEST_RESULT = "testResult";
+
+    public static String USAGE_LIST = QUALITY_MANAGEMENT_NAMESPACE + "list";
+}

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/QmResource.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/QmResource.java
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright (c) 2012 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *     Paul McMahan         - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcOccurs;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcRange;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcReadOnly;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
+import org.eclipse.lyo.oslc4j.core.model.Occurs;
+import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
+import org.eclipse.lyo.oslc4j.core.model.ValueType;
+
+/**
+ * @see http://open-services.net/bin/view/Main/QmSpecificationV2
+ */
+public abstract class QmResource
+       extends AbstractResource
+{
+    private final Set<URI>      rdfTypes                    = new TreeSet<URI>();
+
+    private Date     created;
+    private String   identifier;
+    private URI      instanceShape;
+    private Date     modified;
+    private URI      serviceProvider;
+    private String   title;
+
+    public QmResource()
+     {
+         super();
+
+         rdfTypes.add(getRdfType());
+     }
+
+     public QmResource(final URI about)
+     {
+         super(about);
+
+         rdfTypes.add(getRdfType());
+     }
+
+    protected abstract URI getRdfType();
+
+    public void addRdfType(final URI rdfType)
+    {
+        this.rdfTypes.add(rdfType);
+    }
+
+    @OslcDescription("Timestamp of resource creation.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "created")
+    @OslcReadOnly
+    @OslcTitle("Created")
+    public Date getCreated()
+    {
+        return created;
+    }
+
+    @OslcDescription("A unique identifier for a resource. Assigned by the service provider when a resource is created. Not intended for end-user display.")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "identifier")
+    @OslcReadOnly
+    @OslcTitle("Identifier")
+    public String getIdentifier()
+    {
+        return identifier;
+    }
+
+    @OslcDescription("Resource Shape that provides hints as to resource property value-types and allowed values. ")
+    @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "instanceShape")
+    @OslcRange(OslcConstants.TYPE_RESOURCE_SHAPE)
+    @OslcTitle("Instance Shape")
+    public URI getInstanceShape()
+    {
+        return instanceShape;
+    }
+
+    @OslcDescription("Timestamp last latest resource modification.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "modified")
+    @OslcReadOnly
+    @OslcTitle("Modified")
+    public Date getModified()
+    {
+        return modified;
+    }
+
+    @OslcDescription("The resource type URIs.")
+    @OslcName("type")
+    @OslcPropertyDefinition(OslcConstants.RDF_NAMESPACE + "type")
+    @OslcTitle("Types")
+    public URI[] getRdfTypes()
+    {
+        return rdfTypes.toArray(new URI[rdfTypes.size()]);
+    }
+
+    @OslcDescription("The scope of a resource is a URI for the resource's OSLC Service Provider.")
+    @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "serviceProvider")
+    @OslcRange(OslcConstants.TYPE_SERVICE_PROVIDER)
+    @OslcTitle("Service Provider")
+    public URI getServiceProvider()
+    {
+        return serviceProvider;
+    }
+
+    @OslcDescription("Title (reference: Dublin Core) or often a single line summary of the resource represented as rich text in XHTML content.")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "title")
+    @OslcTitle("Title")
+    @OslcValueType(ValueType.XMLLiteral)
+    public String getTitle()
+    {
+        return title;
+    }
+
+    public void setCreated(final Date created)
+    {
+        this.created = created;
+    }
+
+    public void setIdentifier(final String identifier)
+    {
+        this.identifier = identifier;
+    }
+
+    public void setInstanceShape(final URI instanceShape)
+    {
+        this.instanceShape = instanceShape;
+    }
+
+    public void setModified(final Date modified)
+    {
+        this.modified = modified;
+    }
+
+    public void setRdfTypes(final URI[] rdfTypes)
+    {
+        this.rdfTypes.clear();
+
+        if (rdfTypes != null)
+        {
+            this.rdfTypes.addAll(Arrays.asList(rdfTypes));
+        }
+    }
+
+    public void setServiceProvider(final URI serviceProvider)
+    {
+        this.serviceProvider = serviceProvider;
+    }
+
+    public void setTitle(final String title)
+    {
+        this.title = title;
+    }
+
+}

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/Requirement.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/Requirement.java
@@ -1,0 +1,699 @@
+/*******************************************************************************
+ * Copyright (c) 2013, 2015 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *	 Gabriel Ruelas	   - initial API and implementation
+ *	 Carlos A Arreola	 - initial API and implementation
+ *	 Samuel Padgett	   - avoid unnecessary URISyntaxException
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcOccurs;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcRange;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcReadOnly;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
+import org.eclipse.lyo.oslc4j.core.model.Link;
+import org.eclipse.lyo.oslc4j.core.model.Occurs;
+import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
+import org.eclipse.lyo.oslc4j.core.model.ValueType;
+
+
+@OslcNamespace(RmConstants.REQUIREMENTS_MANAGEMENT_NAMESPACE)
+@OslcResourceShape(title = "Requirement Resource Shape", describes = RmConstants.TYPE_REQUIREMENT)
+public class Requirement
+	   extends AbstractResource
+{
+
+	private String title;
+	private String description;
+	private String identifier;
+	private String   shortTitle;
+	private final Set<String>   subjects					= new TreeSet<String>();
+	private final Set<URI>	  creators					= new TreeSet<URI>();
+	private final Set<URI>	  contributors				= new TreeSet<URI>();
+	private Date created;
+	private Date modified;
+	private final Set<URI>	  rdfTypes					= new TreeSet<URI>();
+	private URI	  serviceProvider;
+	private URI	  instanceShape;
+
+
+	// OSLC Links
+	private final Set<Link>	 elaboratedBy				= new HashSet<Link>();
+	private final Set<Link>	 elaborates		 			= new HashSet<Link>();
+
+	private final Set<Link>	 specifiedBy		   		= new HashSet<Link>();
+	private final Set<Link>	 specifies  					= new HashSet<Link>();
+
+	private final Set<Link>	 affectedBy					= new HashSet<Link>();
+
+	private final Set<Link>	 trackedBy			  	  	= new HashSet<Link>();
+
+	private final Set<Link>	 implementedBy				= new HashSet<Link>();
+
+	private final Set<Link>	 validatedBy					= new HashSet<Link>();
+
+	private final Set<Link>	 satisfiedBy					= new HashSet<Link>();
+	private final Set<Link>	 satisfies					= new HashSet<Link>();
+
+	private final Set<Link>	 decomposedBy				= new HashSet<Link>();
+	private final Set<Link>	 decomposes					= new HashSet<Link>();
+
+	private final Set<Link>	 constrainedBy				= new HashSet<Link>();
+	private final Set<Link>	 constrains					= new HashSet<Link>();
+
+
+	public Requirement()
+	{
+		super();
+
+		// Only add the type if Requirement is the created object
+		if ( ! ( this instanceof RequirementCollection ) ) {
+			rdfTypes.add(URI.create(RmConstants.TYPE_REQUIREMENT));
+		}
+	}
+
+	public Requirement(final URI about)
+	{
+		super(about);
+
+		// Only add the type if Requirement is the created object
+		if ( ! ( this instanceof RequirementCollection ) ) {
+			rdfTypes.add(URI.create(RmConstants.TYPE_REQUIREMENT));
+		}
+	}
+
+	public void addSubject(final String subject)
+	{
+		this.subjects.add(subject);
+	}
+
+	public void addConstrains(final Link constrains)
+	{
+		this.constrains.add(constrains);
+	}
+
+	public void addConstrainedBy(final Link constrainedBy)
+	{
+		this.constrainedBy.add(constrainedBy);
+	}
+
+	public void addDecomposes(final Link decomposes)
+	{
+		this.decomposes.add(decomposes);
+	}
+
+	public void addDecomposedBy(final Link decomposedBy)
+	{
+		this.decomposedBy.add(decomposedBy);
+	}
+
+	public void addSatisfies(final Link satisfies)
+	{
+		this.satisfies.add(satisfies);
+	}
+
+	public void addSatisfiedBy(final Link satisfiedBy)
+	{
+		this.satisfiedBy.add(satisfiedBy);
+	}
+
+	public void addValidatedBy(final Link validatedBy)
+	{
+		this.validatedBy.add(validatedBy);
+	}
+
+	public void addTrackedBy(final Link trackedBy)
+	{
+		this.trackedBy.add(trackedBy);
+	}
+
+	public void addImplementedBy(final Link implementedBy)
+	{
+		this.implementedBy.add(implementedBy);
+	}
+
+	public void addAffectedBy(final Link affectedBy)
+	{
+		this.affectedBy.add(affectedBy);
+	}
+
+	public void addElaboratedBy(final Link elaboratedBy)
+	{
+		this.elaboratedBy.add(elaboratedBy);
+	}
+
+	public void addElaborates(final Link elaborates)
+	{
+		this.elaborates.add(elaborates);
+	}
+
+	public void addSpecifiedBy(final Link specifiedBy)
+	{
+		this.specifiedBy.add(specifiedBy);
+	}
+
+	public void addSpecifies(final Link specifies)
+	{
+		this.specifies.add(specifies);
+	}
+
+	public void addContributor(final URI contributor)
+	{
+		this.contributors.add(contributor);
+	}
+
+	public void addCreator(final URI creator)
+	{
+		this.creators.add(creator);
+	}
+
+	public void addRdfType(final URI rdfType)
+	{
+		this.rdfTypes.add(rdfType);
+	}
+
+	@OslcDescription("Tag or keyword for a resource. Each occurrence of a dcterms:subject property denotes an additional tag for the resource.")
+	@OslcName("subject")
+	@OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "subject")
+	@OslcReadOnly(false)
+	@OslcTitle("Subjects")
+	public String[] getSubjects()
+	{
+		return subjects.toArray(new String[subjects.size()]);
+	}
+
+	@OslcDescription("The subject is elaborated by the object.")
+	@OslcName("elaboratedBy")
+	@OslcPropertyDefinition(RmConstants.REQUIREMENTS_MANAGEMENT_NAMESPACE + "elaboratedBy")
+	@OslcRange(RmConstants.TYPE_REQUIREMENT)
+	@OslcReadOnly(false)
+	@OslcTitle("Elaborated By")
+	public Link[] getElaboratedBy()
+	{
+		return elaboratedBy.toArray(new Link[elaboratedBy.size()]);
+	}
+
+	@OslcDescription("The object is elaborated by the subject.")
+	@OslcName("elaborates")
+	@OslcPropertyDefinition(RmConstants.REQUIREMENTS_MANAGEMENT_NAMESPACE + "elaborates")
+	@OslcRange(RmConstants.TYPE_REQUIREMENT)
+	@OslcReadOnly(false)
+	@OslcTitle("Elaborates")
+	public Link[] getElaborates()
+	{
+		return elaborates.toArray(new Link[elaborates.size()]);
+	}
+
+	@OslcDescription("The subject is specified by the object.")
+	@OslcName("specifiedBy")
+	@OslcPropertyDefinition(RmConstants.REQUIREMENTS_MANAGEMENT_NAMESPACE + "specifiedBy")
+	@OslcRange(RmConstants.TYPE_REQUIREMENT)
+	@OslcReadOnly(false)
+	@OslcTitle("Specified By")
+	public Link[] getSpecifiedBy()
+	{
+		return specifiedBy.toArray(new Link[specifiedBy.size()]);
+	}
+
+	@OslcDescription("The object is specified by the subject.")
+	@OslcName("specifies")
+	@OslcPropertyDefinition(RmConstants.REQUIREMENTS_MANAGEMENT_NAMESPACE + "specifies")
+	@OslcRange(RmConstants.TYPE_REQUIREMENT)
+	@OslcReadOnly(false)
+	@OslcTitle("Specifies")
+	public Link[] getSpecifies()
+	{
+		return specifies.toArray(new Link[specifies.size()]);
+	}
+
+
+	@OslcDescription("Resource, such as a change request, which implements this requirement.")
+	@OslcName("implementedBy")
+	@OslcPropertyDefinition(RmConstants.REQUIREMENTS_MANAGEMENT_NAMESPACE + "implementedBy")
+	@OslcRange(RmConstants.TYPE_REQUIREMENT)
+	@OslcReadOnly(false)
+	@OslcTitle("Implemented By")
+	public Link[] getImplementedBy()
+	{
+		return implementedBy.toArray(new Link[implementedBy.size()]);
+	}
+
+	@OslcDescription("Requirement is affected by a resource, such as a defect or issue.")
+	@OslcName("affectedBy")
+	@OslcPropertyDefinition(RmConstants.REQUIREMENTS_MANAGEMENT_NAMESPACE + "affectedBy")
+	@OslcRange(RmConstants.TYPE_REQUIREMENT)
+	@OslcReadOnly(false)
+	@OslcTitle("Affected By")
+	public Link[] getAffectedBy()
+	{
+		return affectedBy.toArray(new Link[affectedBy.size()]);
+	}
+
+	@OslcDescription("Resource, such as a change request, which tracks this requirement.")
+	@OslcName("trackedBy")
+	@OslcPropertyDefinition(RmConstants.REQUIREMENTS_MANAGEMENT_NAMESPACE + "trackedBy")
+	@OslcRange(RmConstants.TYPE_REQUIREMENT)
+	@OslcReadOnly(false)
+	@OslcTitle("tracked By")
+	public Link[] getTrackedBy()
+	{
+		return trackedBy.toArray(new Link[trackedBy.size()]);
+	}
+
+	@OslcDescription("Resource, such as a test case, which validates this requirement.")
+	@OslcName("validatedBy")
+	@OslcPropertyDefinition(RmConstants.REQUIREMENTS_MANAGEMENT_NAMESPACE + "validatedBy")
+	@OslcRange(RmConstants.TYPE_REQUIREMENT)
+	@OslcReadOnly(false)
+	@OslcTitle("Validated By")
+	public Link[] getValidatedBy()
+	{
+		return validatedBy.toArray(new Link[validatedBy.size()]);
+	}
+
+	@OslcDescription("The subject is satisfied by the object.")
+	@OslcName("satisfiedBy")
+	@OslcPropertyDefinition(RmConstants.REQUIREMENTS_MANAGEMENT_NAMESPACE + "satisfiedBy")
+	@OslcRange(RmConstants.TYPE_REQUIREMENT)
+	@OslcReadOnly(false)
+	@OslcTitle("Satisfied By")
+	public Link[] getSatisfiedBy()
+	{
+		return satisfiedBy.toArray(new Link[satisfiedBy.size()]);
+	}
+
+	@OslcDescription("The object is satisfied by the subject.")
+	@OslcName("satisfies")
+	@OslcPropertyDefinition(RmConstants.REQUIREMENTS_MANAGEMENT_NAMESPACE + "satisfies")
+	@OslcRange(RmConstants.TYPE_REQUIREMENT)
+	@OslcReadOnly(false)
+	@OslcTitle("Satisfies")
+	public Link[] getSatisfies()
+	{
+		return satisfies.toArray(new Link[satisfies.size()]);
+	}
+
+	@OslcDescription("The subject is decomposed by the object.")
+	@OslcName("decomposedBy")
+	@OslcPropertyDefinition(RmConstants.REQUIREMENTS_MANAGEMENT_NAMESPACE + "decomposedBy")
+	@OslcRange(RmConstants.TYPE_REQUIREMENT)
+	@OslcReadOnly(false)
+	@OslcTitle("DecomposedBy")
+	public Link[] getDecomposedBy()
+	{
+		return decomposedBy.toArray(new Link[decomposedBy.size()]);
+	}
+
+	@OslcDescription("The object is decomposed by the subject.")
+	@OslcName("decomposes")
+	@OslcPropertyDefinition(RmConstants.REQUIREMENTS_MANAGEMENT_NAMESPACE + "decomposes")
+	@OslcRange(RmConstants.TYPE_REQUIREMENT)
+	@OslcReadOnly(false)
+	@OslcTitle("Decomposes")
+	public Link[] getDecomposes()
+	{
+		return decomposes.toArray(new Link[decomposes.size()]);
+	}
+
+	@OslcDescription("The subject is constrained by the object.")
+	@OslcName("constrainedBy")
+	@OslcPropertyDefinition(RmConstants.REQUIREMENTS_MANAGEMENT_NAMESPACE + "constrainedBy")
+	@OslcRange(RmConstants.TYPE_REQUIREMENT)
+	@OslcReadOnly(false)
+	@OslcTitle("ConstrainedBy")
+	public Link[] getConstrainedBy()
+	{
+		return constrainedBy.toArray(new Link[constrainedBy.size()]);
+	}
+
+	@OslcDescription("The object is constrained by the subject.")
+	@OslcName("constrains")
+	@OslcPropertyDefinition(RmConstants.REQUIREMENTS_MANAGEMENT_NAMESPACE + "constrains")
+	@OslcRange(RmConstants.TYPE_REQUIREMENT)
+	@OslcReadOnly(false)
+	@OslcTitle("Constrains")
+	public Link[] getConstrains()
+	{
+		return constrains.toArray(new Link[constrains.size()]);
+	}
+
+	@OslcDescription("The person(s) who are responsible for the work needed to complete the change request.")
+	@OslcName("contributor")
+	@OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "contributor")
+	@OslcRange(RmConstants.TYPE_PERSON)
+	@OslcTitle("Contributors")
+	public URI[] getContributors()
+	{
+		return contributors.toArray(new URI[contributors.size()]);
+	}
+
+	@OslcDescription("Timestamp of resource creation.")
+	@OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "created")
+	@OslcReadOnly
+	@OslcTitle("Created")
+	public Date getCreated()
+	{
+		return created;
+	}
+
+	@OslcDescription("Creator or creators of resource.")
+	@OslcName("creator")
+	@OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "creator")
+	@OslcRange(RmConstants.TYPE_PERSON)
+	@OslcTitle("Creators")
+	public URI[] getCreators()
+	{
+		return creators.toArray(new URI[creators.size()]);
+	}
+
+
+	@OslcDescription("Descriptive text (reference: Dublin Core) about resource represented as rich text in XHTML content.")
+	@OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "description")
+	@OslcTitle("Description")
+	@OslcValueType(ValueType.XMLLiteral)
+	public String getDescription()
+	{
+		return description;
+	}
+
+
+	@OslcDescription("A unique identifier for a resource. Assigned by the service provider when a resource is created. Not intended for end-user display.")
+	@OslcOccurs(Occurs.ExactlyOne)
+	@OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "identifier")
+	@OslcReadOnly
+	@OslcTitle("Identifier")
+	public String getIdentifier()
+	{
+		return identifier;
+	}
+
+
+	@OslcDescription("Resource Shape that provides hints as to resource property value-types and allowed values. ")
+	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "instanceShape")
+	@OslcRange(OslcConstants.TYPE_RESOURCE_SHAPE)
+	@OslcTitle("Instance Shape")
+	public URI getInstanceShape()
+	{
+		return instanceShape;
+	}
+
+	@OslcDescription("Timestamp last latest resource modification.")
+	@OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "modified")
+	@OslcReadOnly
+	@OslcTitle("Modified")
+	public Date getModified()
+	{
+		return modified;
+	}
+
+	@OslcDescription("The resource type URIs.")
+	@OslcName("type")
+	@OslcPropertyDefinition(OslcConstants.RDF_NAMESPACE + "type")
+	@OslcTitle("Types")
+	public URI[] getRdfTypes()
+	{
+		return rdfTypes.toArray(new URI[rdfTypes.size()]);
+	}
+
+
+	@OslcDescription("The scope of a resource is a URI for the resource's OSLC Service Provider.")
+	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "serviceProvider")
+	@OslcRange(OslcConstants.TYPE_SERVICE_PROVIDER)
+	@OslcTitle("Service Provider")
+	public URI getServiceProvider()
+	{
+		return serviceProvider;
+	}
+
+	@OslcDescription("Short name identifying a resource, often used as an abbreviated identifier for presentation to end-users.")
+	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "shortTitle")
+	@OslcTitle("Short Title")
+	@OslcValueType(ValueType.XMLLiteral)
+	public String getShortTitle()
+	{
+		return shortTitle;
+	}
+
+
+	@OslcDescription("Title (reference: Dublin Core) or often a single line summary of the resource represented as rich text in XHTML content.")
+	@OslcOccurs(Occurs.ExactlyOne)
+	@OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "title")
+	@OslcTitle("Title")
+	@OslcValueType(ValueType.XMLLiteral)
+	public String getTitle()
+	{
+		return title;
+	}
+
+	public void setConstrains(final Link[] constrains)
+	{
+		this.constrains.clear();
+
+		if (constrains != null)
+		{
+			this.constrains.addAll(Arrays.asList(constrains));
+		}
+	}
+
+	public void setConstrainedBy(final Link[] constrainedBy)
+	{
+		this.constrainedBy.clear();
+
+		if (constrainedBy != null)
+		{
+			this.constrainedBy.addAll(Arrays.asList(constrainedBy));
+		}
+	}
+
+	public void setDecomposes(final Link[] decomposes)
+	{
+		this.affectedBy.clear();
+
+		if (decomposes != null)
+		{
+			this.decomposes.addAll(Arrays.asList(decomposes));
+		}
+	}
+
+	public void setDecomposedBy(final Link[] decomposedBy)
+	{
+		this.decomposedBy.clear();
+
+		if (decomposedBy != null)
+		{
+			this.decomposedBy.addAll(Arrays.asList(decomposedBy));
+		}
+	}
+
+	public void setSatisfies(final Link[] satisfies)
+	{
+		this.satisfies.clear();
+
+		if (satisfies != null)
+		{
+			this.satisfies.addAll(Arrays.asList(satisfies));
+		}
+	}
+
+	public void setSatisfiedBy(final Link[] satisfiedBy)
+	{
+		this.satisfiedBy.clear();
+
+		if (satisfiedBy != null)
+		{
+			this.satisfiedBy.addAll(Arrays.asList(satisfiedBy));
+		}
+	}
+
+	public void setValidatedBy(final Link[] validatedBy)
+	{
+		this.validatedBy.clear();
+
+		if (validatedBy != null)
+		{
+			this.validatedBy.addAll(Arrays.asList(validatedBy));
+		}
+	}
+
+	public void setTrackedBy(final Link[] trackedBy)
+	{
+		this.trackedBy.clear();
+
+		if (trackedBy != null)
+		{
+			this.trackedBy.addAll(Arrays.asList(trackedBy));
+		}
+	}
+
+	public void setAffectedBy(final Link[] affectedBy)
+	{
+		this.affectedBy.clear();
+
+		if (affectedBy != null)
+		{
+			this.affectedBy.addAll(Arrays.asList(affectedBy));
+		}
+	}
+
+	public void setImplementedBy(final Link[] implementedBy)
+	{
+		this.implementedBy.clear();
+
+		if (implementedBy != null)
+		{
+			this.implementedBy.addAll(Arrays.asList(implementedBy));
+		}
+	}
+
+	public void setElaboratedBy(final Link[] elaboratedBy)
+	{
+		this.elaboratedBy.clear();
+
+		if (elaboratedBy != null)
+		{
+			this.elaboratedBy.addAll(Arrays.asList(elaboratedBy));
+		}
+	}
+
+	public void setElaborates(final Link[] elaborates)
+	{
+		this.elaborates.clear();
+
+		if (elaborates != null)
+		{
+			this.elaborates.addAll(Arrays.asList(elaborates));
+		}
+	}
+
+	public void setSpecifiedBy(final Link[] specifiedBy)
+	{
+		this.specifiedBy.clear();
+
+		if (specifiedBy != null)
+		{
+			this.specifiedBy.addAll(Arrays.asList(specifiedBy));
+		}
+	}
+
+
+	public void setSpecifies(final Link[] specifies)
+	{
+		this.specifies.clear();
+
+		if (specifies != null)
+		{
+			this.specifies.addAll(Arrays.asList(specifies));
+		}
+	}
+
+	public void setContributors(final URI[] contributors)
+	{
+		this.contributors.clear();
+
+		if (contributors != null)
+		{
+			this.contributors.addAll(Arrays.asList(contributors));
+		}
+	}
+
+	public void setCreated(final Date created)
+	{
+		this.created = created;
+	}
+
+	public void setCreators(final URI[] creators)
+	{
+		this.creators.clear();
+
+		if (creators != null)
+		{
+			this.creators.addAll(Arrays.asList(creators));
+		}
+	}
+
+
+	public void setDescription(final String description)
+	{
+		this.description = description;
+	}
+
+
+	public void setIdentifier(final String identifier)
+	{
+		this.identifier = identifier;
+	}
+
+
+	public void setInstanceShape(final URI instanceShape)
+	{
+		this.instanceShape = instanceShape;
+	}
+
+	public void setModified(final Date modified)
+	{
+		this.modified = modified;
+	}
+
+	public void setRdfTypes(final URI[] rdfTypes)
+	{
+		this.rdfTypes.clear();
+
+		if (rdfTypes != null)
+		{
+			this.rdfTypes.addAll(Arrays.asList(rdfTypes));
+		}
+	}
+
+
+	public void setServiceProvider(final URI serviceProvider)
+	{
+		this.serviceProvider = serviceProvider;
+	}
+
+	public void setShortTitle(final String shortTitle)
+	{
+		this.shortTitle = shortTitle;
+	}
+
+
+	public void setTitle(final String title)
+	{
+		this.title = title;
+	}
+
+
+	public void setSubjects(final String[] subjects)
+	{
+		this.subjects.clear();
+
+		if (subjects != null)
+		{
+			this.subjects.addAll(Arrays.asList(subjects));
+		}
+	}
+
+}

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/Requirement.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/Requirement.java
@@ -41,6 +41,10 @@ import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
 import org.eclipse.lyo.oslc4j.core.model.ValueType;
 
 
+/**
+ * @see org.eclipse.lyo.oslc.domains.rm.Requirement
+ */
+@Deprecated
 @OslcNamespace(RmConstants.REQUIREMENTS_MANAGEMENT_NAMESPACE)
 @OslcResourceShape(title = "Requirement Resource Shape", describes = RmConstants.TYPE_REQUIREMENT)
 public class Requirement

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/RequirementCollection.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/RequirementCollection.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2013, 2015 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *     Gabriel Ruelas       - initial API and implementation
+ *     Carlos A Arreola     - initial API and implementation
+ *     Samuel Padgett       - avoid unnecessary URISyntaxException
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcRange;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
+
+
+@OslcNamespace(RmConstants.REQUIREMENTS_MANAGEMENT_NAMESPACE)
+@OslcResourceShape(title = "Requirement Collection Resource Shape", describes = RmConstants.TYPE_REQUIREMENT_COLLECTION)
+public final class RequirementCollection
+       extends Requirement
+{
+	// The only extra field is uses
+	private final Set<URI>      uses	 = new TreeSet<URI>();
+
+    public RequirementCollection()
+    {
+        super();
+
+        addRdfType(URI.create(RmConstants.TYPE_REQUIREMENT_COLLECTION));
+    }
+
+    public RequirementCollection(final URI about)
+    {
+        super(about);
+
+        addRdfType(URI.create(RmConstants.TYPE_REQUIREMENT_COLLECTION));
+    }
+
+    public void addUses(final URI uses)
+    {
+        this.uses.add(uses);
+    }
+
+    @OslcDescription("A collection uses a resource - the resource is in the requirement collection.")
+    @OslcName("uses")
+    @OslcPropertyDefinition(RmConstants.REQUIREMENTS_MANAGEMENT_NAMESPACE + "uses")
+    @OslcRange(RmConstants.TYPE_REQUIREMENT)
+    @OslcTitle("Uses")
+    public URI[] getUses()
+    {
+        return uses.toArray(new URI[uses.size()]);
+    }
+
+    public void setUses(final URI[] uses)
+    {
+        this.uses.clear();
+
+        if (uses != null)
+        {
+            this.uses.addAll(Arrays.asList(uses));
+        }
+    }
+
+}

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/RequirementCollection.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/RequirementCollection.java
@@ -31,6 +31,10 @@ import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
 
 
+/**
+ * @see org.eclipse.lyo.oslc.domains.rm.RequirementCollection
+ */
+@Deprecated
 @OslcNamespace(RmConstants.REQUIREMENTS_MANAGEMENT_NAMESPACE)
 @OslcResourceShape(title = "Requirement Collection Resource Shape", describes = RmConstants.TYPE_REQUIREMENT_COLLECTION)
 public final class RequirementCollection

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/RmConstants.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/RmConstants.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2013 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *     Gabriel Ruelas       - initial API and implementation
+ *     Carlos A Arreola     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+import javax.xml.namespace.QName;
+
+import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
+
+import org.apache.jena.datatypes.BaseDatatype;
+
+public interface RmConstants
+{
+    public static String REQUIREMENTS_MANAGEMENT_DOMAIN                    = "http://open-services.net/ns/rm#";
+    public static String REQUIREMENTS_MANAGEMENT_NAMESPACE                 = "http://open-services.net/ns/rm#";
+
+
+    public static String REQUIREMENTS_MANAGEMENT_PREFIX              = "oslc_rm";
+    public static String SOFTWARE_CONFIGURATION_MANAGEMENT_PREFIX    = "oslc_scm";
+    public static String QUALITY_MANAGEMENT_PREFIX                   = "oslc_qm";
+
+
+    public static String FOAF_NAMESPACE                              = "http://xmlns.com/foaf/0.1/";
+    public static String FOAF_NAMESPACE_PREFIX                       = "foaf";
+
+    public static String TYPE_DISCUSSION            = OslcConstants.OSLC_CORE_NAMESPACE + "Discussion";
+    public static String TYPE_PERSON                = FOAF_NAMESPACE + "Person";
+    public static String TYPE_REQUIREMENT           = REQUIREMENTS_MANAGEMENT_NAMESPACE + "Requirement";
+    public static String TYPE_REQUIREMENT_COLLECTION           = REQUIREMENTS_MANAGEMENT_NAMESPACE + "RequirementCollection";
+
+
+    public static String JAZZ_RM_NAMESPACE                 = "http://jazz.net/ns/rm#";
+    public static String JAZZ_RM_NAV_NAMESPACE             = "http://jazz.net/ns/rm/navigation#";
+    public static String JAZZ_RM_ACCESS_NAMESPACE         = "http://jazz.net/ns/acp#";
+
+    QName PROPERTY_PRIMARY_TEXT   = new QName(RmConstants.JAZZ_RM_NAMESPACE, "primaryText");
+    QName PROPERTY_PARENT_FOLDER  = new QName(RmConstants.JAZZ_RM_NAV_NAMESPACE, "parent");
+    QName PROPERTY_ACCESS_CONTROL = new QName(RmConstants.JAZZ_RM_ACCESS_NAMESPACE, "accessControl");
+
+
+
+    public static final BaseDatatype RDF_TYPE_BOOLEAN 	= new BaseDatatype(OslcConstants.RDF_NAMESPACE + "boolean");
+    public static final BaseDatatype RDF_TYPE_DATETIME 	= new BaseDatatype(OslcConstants.RDF_NAMESPACE + "dateTime");
+    public static final BaseDatatype RDF_TYPE_DECIMAL	 = new BaseDatatype(OslcConstants.RDF_NAMESPACE + "decimal");
+    public static final BaseDatatype RDF_TYPE_DOUBLE	 = new BaseDatatype(OslcConstants.RDF_NAMESPACE + "double");
+    public static final BaseDatatype RDF_TYPE_FLOAT		 = new BaseDatatype(OslcConstants.RDF_NAMESPACE + "float");
+    public static final BaseDatatype RDF_TYPE_INTEGER	 = new BaseDatatype(OslcConstants.RDF_NAMESPACE + "integer");
+    public static final BaseDatatype RDF_TYPE_STRING	 = new BaseDatatype(OslcConstants.RDF_NAMESPACE + "string");
+    public static final BaseDatatype RDF_TYPE_XMLLITERAL = new BaseDatatype(OslcConstants.RDF_NAMESPACE + "XMLLiteral");
+    public static final BaseDatatype RDF_TYPE_RESOURCE	 = new BaseDatatype(OslcConstants.RDF_NAMESPACE + "Resource");
+    public static final BaseDatatype RDF_TYPE_LOCALRESOURCE	 = new BaseDatatype(OslcConstants.RDF_NAMESPACE + "LocalResource");
+
+    String NAMESPACE_URI_XHTML       = "http://www.w3.org/1999/xhtml"; //$NON-NLS-1$
+
+
+
+
+}

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/TestCase.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/TestCase.java
@@ -1,0 +1,256 @@
+/*******************************************************************************
+ * Copyright (c) 2012 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *     Paul McMahan         - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcRange;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcReadOnly;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.eclipse.lyo.oslc4j.core.model.Link;
+import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
+import org.eclipse.lyo.oslc4j.core.model.ValueType;
+
+@OslcResourceShape(title = "Quality Management Resource Shape", describes = QmConstants.TYPE_TEST_CASE)
+@OslcNamespace(QmConstants.QUALITY_MANAGEMENT_NAMESPACE)
+/**
+ * @see http://open-services.net/bin/view/Main/QmSpecificationV2#Resource_TestCase
+ */
+public final class TestCase
+       extends QmResource
+{
+    private final Set<URI>      contributors                = new TreeSet<URI>();
+    private final Set<URI>      creators                    = new TreeSet<URI>();
+    private final Set<Link>     relatedChangeRequests       = new HashSet<Link>();
+    private final Set<String>   subjects                    = new TreeSet<String>();
+    private final Set<Link>     testsChangeRequests         = new HashSet<Link>();
+    private final Set<Link>     usesTestScripts             = new HashSet<Link>();
+    private final Set<Link>     validatesRequirements       = new HashSet<Link>();
+
+    private String   description;
+
+    public TestCase()
+    {
+        super();
+    }
+
+    protected URI getRdfType() {
+    	return URI.create(QmConstants.TYPE_TEST_CASE);
+    }
+
+    public void addContributor(final URI contributor)
+    {
+        this.contributors.add(contributor);
+    }
+
+    public void addCreator(final URI creator)
+    {
+        this.creators.add(creator);
+    }
+
+    public void addRelatedChangeRequest(final Link relatedChangeRequest)
+    {
+        this.relatedChangeRequests.add(relatedChangeRequest);
+    }
+
+    public void addSubject(final String subject)
+    {
+        this.subjects.add(subject);
+    }
+
+    public void addTestsChangeRequest(final Link changeRequest)
+    {
+        this.testsChangeRequests.add(changeRequest);
+    }
+
+    public void addUsesTestScript(final Link testscript)
+    {
+        this.usesTestScripts.add(testscript);
+    }
+
+    public void addValidatesRequirement(final Link requirement)
+    {
+        this.validatesRequirements.add(requirement);
+    }
+
+    @OslcDescription("The person(s) who are responsible for the work needed to complete the test case.")
+    @OslcName("contributor")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "contributor")
+    @OslcRange(QmConstants.TYPE_PERSON)
+    @OslcTitle("Contributors")
+    public URI[] getContributors()
+    {
+        return contributors.toArray(new URI[contributors.size()]);
+    }
+
+    @OslcDescription("Creator or creators of resource.")
+    @OslcName("creator")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "creator")
+    @OslcRange(QmConstants.TYPE_PERSON)
+    @OslcTitle("Creators")
+    public URI[] getCreators()
+    {
+        return creators.toArray(new URI[creators.size()]);
+    }
+
+    @OslcDescription("Descriptive text (reference: Dublin Core) about resource represented as rich text in XHTML content.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "description")
+    @OslcTitle("Description")
+    @OslcValueType(ValueType.XMLLiteral)
+    public String getDescription()
+    {
+        return description;
+    }
+
+    @OslcDescription("A related change request.")
+    @OslcName("relatedChangeRequest")
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "relatedChangeRequest")
+    @OslcRange(QmConstants.TYPE_CHANGE_REQUEST)
+    @OslcReadOnly(false)
+    @OslcTitle("Related Change Requests")
+    public Link[] getRelatedChangeRequests()
+    {
+        return relatedChangeRequests.toArray(new Link[relatedChangeRequests.size()]);
+    }
+
+    @OslcDescription("Tag or keyword for a resource. Each occurrence of a dcterms:subject property denotes an additional tag for the resource.")
+    @OslcName("subject")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "subject")
+    @OslcReadOnly(false)
+    @OslcTitle("Subjects")
+    public String[] getSubjects()
+    {
+        return subjects.toArray(new String[subjects.size()]);
+    }
+
+    @OslcDescription("Change Request tested by the Test Case.")
+    @OslcName("testsChangeRequest")
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "testsChangeRequest")
+    @OslcRange(QmConstants.TYPE_CHANGE_REQUEST)
+    @OslcReadOnly(false)
+    @OslcTitle("Tests Change Request")
+    public Link[] getTestsChangeRequests()
+    {
+        return testsChangeRequests.toArray(new Link[testsChangeRequests.size()]);
+    }
+
+    @OslcDescription("Test Script used by the Test Case.")
+    @OslcName("usesTestScript")
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "usesTestScript")
+    @OslcRange(QmConstants.TYPE_TEST_SCRIPT)
+    @OslcReadOnly(false)
+    @OslcTitle("Uses Test Script")
+    public Link[] getUsesTestScripts()
+    {
+        return usesTestScripts.toArray(new Link[usesTestScripts.size()]);
+    }
+
+    @OslcDescription("Requirement that is validated by the Test Case.")
+    @OslcName("validatesRequirement")
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "validatesRequirement")
+    @OslcRange(QmConstants.TYPE_REQUIREMENT)
+    @OslcReadOnly(false)
+    @OslcTitle("Validates Requirement")
+    public Link[] getValidatesRequirements()
+    {
+        return validatesRequirements.toArray(new Link[validatesRequirements.size()]);
+    }
+
+    public void setContributors(final URI[] contributors)
+    {
+        this.contributors.clear();
+
+        if (contributors != null)
+        {
+            this.contributors.addAll(Arrays.asList(contributors));
+        }
+    }
+
+    public void setCreators(final URI[] creators)
+    {
+        this.creators.clear();
+
+        if (creators != null)
+        {
+            this.creators.addAll(Arrays.asList(creators));
+        }
+    }
+
+    public void setDescription(final String description)
+    {
+        this.description = description;
+    }
+
+    public void setRelatedChangeRequests(final Link[] relatedChangeRequests)
+    {
+        this.relatedChangeRequests.clear();
+
+        if (relatedChangeRequests != null)
+        {
+            this.relatedChangeRequests.addAll(Arrays.asList(relatedChangeRequests));
+        }
+    }
+
+    public void setSubjects(final String[] subjects)
+    {
+        this.subjects.clear();
+
+        if (subjects != null)
+        {
+            this.subjects.addAll(Arrays.asList(subjects));
+        }
+    }
+
+    public void setTestsChangeRequests(final Link[] testsChangeRequests)
+    {
+        this.testsChangeRequests.clear();
+
+        if (testsChangeRequests != null)
+        {
+            this.testsChangeRequests.addAll(Arrays.asList(testsChangeRequests));
+        }
+    }
+
+    public void setUsesTestScripts(final Link[] usesTestScripts)
+    {
+        this.usesTestScripts.clear();
+
+        if (usesTestScripts != null)
+        {
+            this.usesTestScripts.addAll(Arrays.asList(usesTestScripts));
+        }
+    }
+
+    public void setValidatesRequirements(final Link[] validatesRequirements)
+    {
+        this.validatesRequirements.clear();
+
+        if (validatesRequirements != null)
+        {
+            this.validatesRequirements.addAll(Arrays.asList(validatesRequirements));
+        }
+    }
+}

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/TestCase.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/TestCase.java
@@ -34,11 +34,12 @@ import org.eclipse.lyo.oslc4j.core.model.Link;
 import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
 import org.eclipse.lyo.oslc4j.core.model.ValueType;
 
+/**
+ * @see org.eclipse.lyo.oslc.domains.qm.TestCase
+ */
+@Deprecated
 @OslcResourceShape(title = "Quality Management Resource Shape", describes = QmConstants.TYPE_TEST_CASE)
 @OslcNamespace(QmConstants.QUALITY_MANAGEMENT_NAMESPACE)
-/**
- * @see http://open-services.net/bin/view/Main/QmSpecificationV2#Resource_TestCase
- */
 public final class TestCase
        extends QmResource
 {

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/TestExecutionRecord.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/TestExecutionRecord.java
@@ -32,11 +32,12 @@ import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
 import org.eclipse.lyo.oslc4j.core.model.Link;
 import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
 
+/**
+ * @see org.eclipse.lyo.oslc.domains.qm.TestExecutionRecord
+ */
+@Deprecated
 @OslcResourceShape(title = "Quality Management Resource Shape", describes = QmConstants.TYPE_TEST_EXECUTION_RECORD)
 @OslcNamespace(QmConstants.QUALITY_MANAGEMENT_NAMESPACE)
-/**
- * @see http://open-services.net/bin/view/Main/QmSpecificationV2#Resource_TestExecutionRecord
- */
 public final class TestExecutionRecord
        extends QmResource
 {

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/TestExecutionRecord.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/TestExecutionRecord.java
@@ -1,0 +1,208 @@
+/*******************************************************************************
+ * Copyright (c) 2012 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *     Paul McMahan         - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcRange;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcReadOnly;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
+import org.eclipse.lyo.oslc4j.core.model.Link;
+import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
+
+@OslcResourceShape(title = "Quality Management Resource Shape", describes = QmConstants.TYPE_TEST_EXECUTION_RECORD)
+@OslcNamespace(QmConstants.QUALITY_MANAGEMENT_NAMESPACE)
+/**
+ * @see http://open-services.net/bin/view/Main/QmSpecificationV2#Resource_TestExecutionRecord
+ */
+public final class TestExecutionRecord
+       extends QmResource
+{
+    private final Set<Link>     blockedByChangeRequests       = new HashSet<Link>();
+    private final Set<URI>      contributors                = new TreeSet<URI>();
+    private final Set<URI>      creators                    = new TreeSet<URI>();
+    private final Set<Link>     relatedChangeRequests       = new HashSet<Link>();
+
+    private Link     reportsOnTestPlan;
+    private URI      runsOnTestEnvironment;
+    private Link     runsTestCase;
+
+    public TestExecutionRecord()
+    {
+        super();
+    }
+
+    protected URI getRdfType() {
+    	return URI.create(QmConstants.TYPE_TEST_EXECUTION_RECORD);
+    }
+
+    public void addBlockedByChangeRequest(final Link blockingChangeRequest)
+    {
+        this.blockedByChangeRequests.add(blockingChangeRequest);
+    }
+
+    public void addContributor(final URI contributor)
+    {
+        this.contributors.add(contributor);
+    }
+
+    public void addCreator(final URI creator)
+    {
+        this.creators.add(creator);
+    }
+
+    public void addRelatedChangeRequest(final Link relatedChangeRequest)
+    {
+        this.relatedChangeRequests.add(relatedChangeRequest);
+    }
+
+    @OslcDescription("The person(s) who are responsible for the work needed to complete the change request.")
+    @OslcName("contributor")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "contributor")
+    @OslcRange(QmConstants.TYPE_PERSON)
+    @OslcTitle("Contributors")
+    public URI[] getContributors()
+    {
+        return contributors.toArray(new URI[contributors.size()]);
+    }
+
+    @OslcDescription("Creator or creators of resource.")
+    @OslcName("creator")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "creator")
+    @OslcRange(QmConstants.TYPE_PERSON)
+    @OslcTitle("Creators")
+    public URI[] getCreators()
+    {
+        return creators.toArray(new URI[creators.size()]);
+    }
+
+    @OslcDescription("Change Request that prevents execution of the Test Execution Record.")
+    @OslcName("blockedByChangeRequest")
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "blockedByChangeRequest")
+    @OslcRange(QmConstants.TYPE_CHANGE_REQUEST)
+    @OslcReadOnly(false)
+    @OslcTitle("Blocked By Change Request")
+    public Link[] getBlockedByChangeRequests()
+    {
+        return blockedByChangeRequests.toArray(new Link[blockedByChangeRequests.size()]);
+    }
+
+    @OslcDescription("This relationship is loosely coupled and has no specific meaning.")
+    @OslcName("relatedChangeRequest")
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "relatedChangeRequest")
+    @OslcRange(QmConstants.TYPE_CHANGE_REQUEST)
+    @OslcReadOnly(false)
+    @OslcTitle("Related Change Requests")
+    public Link[] getRelatedChangeRequests()
+    {
+        return relatedChangeRequests.toArray(new Link[relatedChangeRequests.size()]);
+    }
+
+    @OslcDescription("Test Plan that the Test Execution Record reports on.")
+    @OslcName("reportsOnTestPlan")
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "reportsOnTestPlan")
+    @OslcRange(QmConstants.TYPE_TEST_PLAN)
+    @OslcReadOnly(false)
+    @OslcTitle("Reports On Test Plan")
+    public Link getReportsOnTestPlan()
+    {
+        return reportsOnTestPlan;
+    }
+
+    @OslcDescription("Indicates the environment details of the test case for this execution record.")
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "runsOnTestEnvironment")
+    @OslcTitle("Runs On Test Environment")
+    public URI getRunsOnTestEnvironment()
+    {
+        return runsOnTestEnvironment;
+    }
+
+    @OslcDescription("Test Case run by the Test Execution Record.")
+    @OslcName("runsTestCase")
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "runsTestCase")
+    @OslcRange(QmConstants.TYPE_TEST_CASE)
+    @OslcReadOnly(false)
+    @OslcTitle("Runs Test Case")
+    public Link getRunsTestCase()
+    {
+        return runsTestCase;
+    }
+
+    public void setBlockedByChangeRequests(final Link[] blockedByChangeRequests)
+    {
+        this.blockedByChangeRequests.clear();
+
+        if (blockedByChangeRequests != null)
+        {
+            this.blockedByChangeRequests.addAll(Arrays.asList(blockedByChangeRequests));
+        }
+    }
+
+    public void setContributors(final URI[] contributors)
+    {
+        this.contributors.clear();
+
+        if (contributors != null)
+        {
+            this.contributors.addAll(Arrays.asList(contributors));
+        }
+    }
+
+    public void setCreators(final URI[] creators)
+    {
+        this.creators.clear();
+
+        if (creators != null)
+        {
+            this.creators.addAll(Arrays.asList(creators));
+        }
+    }
+
+    public void setRelatedChangeRequests(final Link[] relatedChangeRequests)
+    {
+        this.relatedChangeRequests.clear();
+
+        if (relatedChangeRequests != null)
+        {
+            this.relatedChangeRequests.addAll(Arrays.asList(relatedChangeRequests));
+        }
+    }
+
+    public void setReportsOnTestPlan(final Link reportsOnTestPlan)
+    {
+        this.reportsOnTestPlan = reportsOnTestPlan;
+    }
+
+    public void setRunsOnTestEnvironment(final URI runsOnTestEnvironment)
+    {
+        this.runsOnTestEnvironment = runsOnTestEnvironment;
+    }
+
+    public void setRunsTestCase(final Link runsTestCase)
+    {
+        this.runsTestCase = runsTestCase;
+    }
+
+}

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/TestPlan.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/TestPlan.java
@@ -34,11 +34,12 @@ import org.eclipse.lyo.oslc4j.core.model.Link;
 import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
 import org.eclipse.lyo.oslc4j.core.model.ValueType;
 
+/**
+ * @see org.eclipse.lyo.oslc.domains.qm.TestPlan
+ */
+@Deprecated
 @OslcResourceShape(title = "Quality Management Resource Shape", describes = QmConstants.TYPE_TEST_PLAN)
 @OslcNamespace(QmConstants.QUALITY_MANAGEMENT_NAMESPACE)
-/**
- * @see http://open-services.net/bin/view/Main/QmSpecificationV2#Resource_TestPlan
- */
 public final class TestPlan
        extends QmResource
 {

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/TestPlan.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/TestPlan.java
@@ -1,0 +1,229 @@
+/*******************************************************************************
+ * Copyright (c) 2012 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *     Paul McMahan         - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcRange;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcReadOnly;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.eclipse.lyo.oslc4j.core.model.Link;
+import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
+import org.eclipse.lyo.oslc4j.core.model.ValueType;
+
+@OslcResourceShape(title = "Quality Management Resource Shape", describes = QmConstants.TYPE_TEST_PLAN)
+@OslcNamespace(QmConstants.QUALITY_MANAGEMENT_NAMESPACE)
+/**
+ * @see http://open-services.net/bin/view/Main/QmSpecificationV2#Resource_TestPlan
+ */
+public final class TestPlan
+       extends QmResource
+{
+	private final Set<URI>      contributors                = new TreeSet<URI>();
+    private final Set<URI>      creators                    = new TreeSet<URI>();
+    private final Set<Link>     relatedChangeRequests       = new HashSet<Link>();
+    private final Set<String>   subjects                    = new TreeSet<String>();
+    private final Set<Link>     usesTestCases               = new HashSet<Link>();
+    private final Set<Link>     validatesRequirementCollections = new HashSet<Link>();
+
+    private String   description;
+
+	public TestPlan()
+	{
+		super();
+	}
+
+    protected URI getRdfType() {
+    	return URI.create(QmConstants.TYPE_TEST_PLAN);
+    }
+
+    public void addContributor(final URI contributor)
+    {
+        this.contributors.add(contributor);
+    }
+
+    public void addCreator(final URI creator)
+    {
+        this.creators.add(creator);
+    }
+
+    public void addRelatedChangeRequest(final Link relatedChangeRequest)
+    {
+        this.relatedChangeRequests.add(relatedChangeRequest);
+    }
+
+    public void addSubject(final String subject)
+    {
+        this.subjects.add(subject);
+    }
+
+    public void addUsesTestCase(final Link testcase)
+    {
+        this.usesTestCases.add(testcase);
+    }
+
+    public void addValidatesRequirementCollection(final Link requirementCollection)
+    {
+        this.validatesRequirementCollections.add(requirementCollection);
+    }
+
+    @OslcDescription("The person(s) who are responsible for the work needed to complete the change request.")
+    @OslcName("contributor")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "contributor")
+    @OslcRange(QmConstants.TYPE_PERSON)
+    @OslcTitle("Contributors")
+    public URI[] getContributors()
+    {
+        return contributors.toArray(new URI[contributors.size()]);
+    }
+
+    @OslcDescription("Creator or creators of resource.")
+    @OslcName("creator")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "creator")
+    @OslcRange(QmConstants.TYPE_PERSON)
+    @OslcTitle("Creators")
+    public URI[] getCreators()
+    {
+        return creators.toArray(new URI[creators.size()]);
+    }
+
+    @OslcDescription("Descriptive text (reference: Dublin Core) about resource represented as rich text in XHTML content.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "description")
+    @OslcTitle("Description")
+    @OslcValueType(ValueType.XMLLiteral)
+    public String getDescription()
+    {
+        return description;
+    }
+
+    @OslcDescription("A related change request.")
+    @OslcName("relatedChangeRequest")
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "relatedChangeRequest")
+    @OslcRange(QmConstants.TYPE_CHANGE_REQUEST)
+    @OslcReadOnly(false)
+    @OslcTitle("Related Change Requests")
+    public Link[] getRelatedChangeRequests()
+    {
+        return relatedChangeRequests.toArray(new Link[relatedChangeRequests.size()]);
+    }
+
+    @OslcDescription("Tag or keyword for a resource. Each occurrence of a dcterms:subject property denotes an additional tag for the resource.")
+    @OslcName("subject")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "subject")
+    @OslcReadOnly(false)
+    @OslcTitle("Subjects")
+    public String[] getSubjects()
+    {
+        return subjects.toArray(new String[subjects.size()]);
+    }
+
+    @OslcDescription("Test Case used by the Test Plan.")
+    @OslcName("usesTestCase")
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "usesTestCase")
+    @OslcRange(QmConstants.TYPE_TEST_CASE)
+    @OslcReadOnly(false)
+    @OslcTitle("Uses Test Case")
+    public Link[] getUsesTestCases()
+    {
+        return usesTestCases.toArray(new Link[usesTestCases.size()]);
+    }
+
+    @OslcDescription("Requirement Collection that is validated by the Test Plan.")
+    @OslcName("validatesRequirementCollection")
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "validatesRequirementCollection")
+    @OslcRange(QmConstants.TYPE_REQUIREMENT_COLLECTION)
+    @OslcReadOnly(false)
+    @OslcTitle("Validates Requirement Collection")
+    public Link[] getValidatesRequirementCollections()
+    {
+        return validatesRequirementCollections.toArray(new Link[validatesRequirementCollections.size()]);
+    }
+
+    public void setContributors(final URI[] contributors)
+    {
+        this.contributors.clear();
+
+        if (contributors != null)
+        {
+            this.contributors.addAll(Arrays.asList(contributors));
+        }
+    }
+
+    public void setCreators(final URI[] creators)
+    {
+        this.creators.clear();
+
+        if (creators != null)
+        {
+            this.creators.addAll(Arrays.asList(creators));
+        }
+    }
+
+    public void setDescription(final String description)
+    {
+        this.description = description;
+    }
+
+    public void setRelatedChangeRequests(final Link[] relatedChangeRequests)
+    {
+        this.relatedChangeRequests.clear();
+
+        if (relatedChangeRequests != null)
+        {
+            this.relatedChangeRequests.addAll(Arrays.asList(relatedChangeRequests));
+        }
+    }
+
+    public void setSubjects(final String[] subjects)
+    {
+        this.subjects.clear();
+
+        if (subjects != null)
+        {
+            this.subjects.addAll(Arrays.asList(subjects));
+        }
+    }
+
+    public void setUsesTestCases(final Link[] usesTestCases)
+    {
+        this.usesTestCases.clear();
+
+        if (usesTestCases != null)
+        {
+            this.usesTestCases.addAll(Arrays.asList(usesTestCases));
+        }
+    }
+
+    public void setValidatesRequirementCollections(final Link[] validatesRequirementCollections)
+    {
+        this.validatesRequirementCollections.clear();
+
+        if (validatesRequirementCollections != null)
+        {
+            this.validatesRequirementCollections.addAll(Arrays.asList(validatesRequirementCollections));
+        }
+    }
+}

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/TestResult.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/TestResult.java
@@ -34,6 +34,10 @@ import org.eclipse.lyo.oslc4j.core.model.Link;
 import org.eclipse.lyo.oslc4j.core.model.Occurs;
 import org.eclipse.lyo.oslc4j.core.model.ValueType;
 
+/**
+ * @see org.eclipse.lyo.oslc.domains.qm.TestResult
+ */
+@Deprecated
 @OslcResourceShape(title = "Quality Management Resource Shape", describes = QmConstants.TYPE_TEST_RESULT)
 @OslcNamespace(QmConstants.QUALITY_MANAGEMENT_NAMESPACE)
 /**

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/TestResult.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/TestResult.java
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * Copyright (c) 2012 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *     Paul McMahan         - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcOccurs;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcRange;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcReadOnly;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.eclipse.lyo.oslc4j.core.model.Link;
+import org.eclipse.lyo.oslc4j.core.model.Occurs;
+import org.eclipse.lyo.oslc4j.core.model.ValueType;
+
+@OslcResourceShape(title = "Quality Management Resource Shape", describes = QmConstants.TYPE_TEST_RESULT)
+@OslcNamespace(QmConstants.QUALITY_MANAGEMENT_NAMESPACE)
+/**
+ * @see http://open-services.net/bin/view/Main/QmSpecificationV2#Resource_TestResult
+ */
+public final class TestResult
+       extends QmResource
+{
+    private final Set<Link>     affectedByChangeRequests       = new HashSet<Link>();
+
+    private Link     executesTestScript;
+    private Link     reportsOnTestCase;
+    private Link     reportsOnTestPlan;
+    private Link     producedByTestExecutionRecord;
+    private String   status;
+
+    public TestResult()
+    {
+        super();
+    }
+
+    protected URI getRdfType() {
+    	return URI.create(QmConstants.TYPE_TEST_RESULT);
+    }
+
+    public void addAffectedByChangeRequest(final Link affectingChangeRequest)
+    {
+        this.affectedByChangeRequests.add(affectingChangeRequest);
+    }
+
+    @OslcDescription("Change request that affects the Test Result.")
+    @OslcName("affectedByChangeRequest")
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "affectedByChangeRequest")
+    @OslcRange(QmConstants.TYPE_CHANGE_REQUEST)
+    @OslcReadOnly(false)
+    @OslcTitle("Affected By Change Request")
+    public Link[] getAffectedByChangeRequests()
+    {
+        return affectedByChangeRequests.toArray(new Link[affectedByChangeRequests.size()]);
+    }
+
+    @OslcDescription("Test Plan that the Test Result reports on.")
+    @OslcName("reportsOnTestPlan")
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "reportsOnTestPlan")
+    @OslcRange(QmConstants.TYPE_TEST_PLAN)
+    @OslcReadOnly(false)
+    @OslcTitle("Reports On Test Plan")
+    public Link getReportsOnTestPlan()
+    {
+        return reportsOnTestPlan;
+    }
+
+    @OslcDescription("Test Case that the Test Result reports on.")
+    @OslcName("reportsOnTestCase")
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "reportsOnTestCase")
+    @OslcRange(QmConstants.TYPE_TEST_CASE)
+    @OslcReadOnly(false)
+    @OslcTitle("Reports On Test Case")
+    public Link getReportsOnTestCase()
+    {
+        return reportsOnTestCase;
+    }
+
+    @OslcDescription("Test Script executed to produce the Test Result.")
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "executesTestScript")
+    @OslcTitle("Executes Test Script")
+    public Link getExecutesTestScript()
+    {
+        return executesTestScript;
+    }
+
+    @OslcDescription("Test Execution Record that the Test Result was produced by.")
+    @OslcName("producedByTestExecutionRecord")
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "producedByTestExecutionRecord")
+    @OslcRange(QmConstants.TYPE_TEST_EXECUTION_RECORD)
+    @OslcReadOnly(false)
+    @OslcTitle("Produced By Test Execution Record")
+    public Link getProducedByTestExecutionRecord()
+    {
+        return producedByTestExecutionRecord;
+    }
+
+    @OslcDescription("Used to indicate the state of the Test Result based on values defined by the service provider.")
+    @OslcOccurs(Occurs.ZeroOrOne)
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "status")
+    @OslcTitle("Status")
+    @OslcValueType(ValueType.XMLLiteral)
+    public String getStatus()
+    {
+        return status;
+    }
+
+    public void setAffectedByChangeRequests(final Link[] affectedByChangeRequests)
+    {
+        this.affectedByChangeRequests.clear();
+
+        if (affectedByChangeRequests != null)
+        {
+            this.affectedByChangeRequests.addAll(Arrays.asList(affectedByChangeRequests));
+        }
+    }
+
+    public void setReportsOnTestPlan(final Link reportsOnTestPlan)
+    {
+        this.reportsOnTestPlan = reportsOnTestPlan;
+    }
+
+    public void setReportsOnTestCase(final Link reportsOnTestCase)
+    {
+        this.reportsOnTestCase = reportsOnTestCase;
+    }
+
+    public void setProducedByTestExecutionRecord(final Link producedByTestExecutionRecord)
+    {
+        this.producedByTestExecutionRecord = producedByTestExecutionRecord;
+    }
+
+    public void setExecutesTestScript(final Link executesTestScript)
+    {
+        this.executesTestScript = executesTestScript;
+    }
+
+    public void setStatus(final String status)
+    {
+        this.status = status;
+    }
+
+}

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/TestScript.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/TestScript.java
@@ -34,11 +34,12 @@ import org.eclipse.lyo.oslc4j.core.model.Link;
 import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
 import org.eclipse.lyo.oslc4j.core.model.ValueType;
 
+/**
+ * @see org.eclipse.lyo.oslc.domains.qm.TestScript
+ */
+@Deprecated
 @OslcResourceShape(title = "Quality Management Resource Shape", describes = QmConstants.TYPE_TEST_SCRIPT)
 @OslcNamespace(QmConstants.QUALITY_MANAGEMENT_NAMESPACE)
-/**
- * @see http://open-services.net/bin/view/Main/QmSpecificationV2#Resource_TestScript
- */
 public final class TestScript
        extends QmResource
 {

--- a/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/TestScript.java
+++ b/oslc-domains/src/main/java/org/eclipse/lyo/client/oslc/resources/TestScript.java
@@ -1,0 +1,190 @@
+/*******************************************************************************
+ * Copyright (c) 2012 IBM Corporation.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *
+ *     Paul McMahan         - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lyo.client.oslc.resources;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcRange;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcReadOnly;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.eclipse.lyo.oslc4j.core.model.Link;
+import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
+import org.eclipse.lyo.oslc4j.core.model.ValueType;
+
+@OslcResourceShape(title = "Quality Management Resource Shape", describes = QmConstants.TYPE_TEST_SCRIPT)
+@OslcNamespace(QmConstants.QUALITY_MANAGEMENT_NAMESPACE)
+/**
+ * @see http://open-services.net/bin/view/Main/QmSpecificationV2#Resource_TestScript
+ */
+public final class TestScript
+       extends QmResource
+{
+    private final Set<URI>      contributors                = new TreeSet<URI>();
+    private final Set<URI>      creators                    = new TreeSet<URI>();
+    private final Set<Link>     relatedChangeRequests       = new HashSet<Link>();
+    private final Set<Link>     validatesRequirements       = new HashSet<Link>();
+
+    private URI      executionInstructions;
+    private String   description;
+
+    public TestScript()
+    {
+        super();
+    }
+
+    protected URI getRdfType() {
+    	return URI.create(QmConstants.TYPE_TEST_SCRIPT);
+    }
+
+    public void addContributor(final URI contributor)
+    {
+        this.contributors.add(contributor);
+    }
+
+    public void addCreator(final URI creator)
+    {
+        this.creators.add(creator);
+    }
+
+    public void addRelatedChangeRequest(final Link relatedChangeRequest)
+    {
+        this.relatedChangeRequests.add(relatedChangeRequest);
+    }
+
+    public void addValidatesRequirement(final Link requirement)
+    {
+        this.validatesRequirements.add(requirement);
+    }
+
+    @OslcDescription("The person(s) who are responsible for the work needed to complete the change request.")
+    @OslcName("contributor")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "contributor")
+    @OslcRange(QmConstants.TYPE_PERSON)
+    @OslcTitle("Contributors")
+    public URI[] getContributors()
+    {
+        return contributors.toArray(new URI[contributors.size()]);
+    }
+
+    @OslcDescription("Creator or creators of resource.")
+    @OslcName("creator")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "creator")
+    @OslcRange(QmConstants.TYPE_PERSON)
+    @OslcTitle("Creators")
+    public URI[] getCreators()
+    {
+        return creators.toArray(new URI[creators.size()]);
+    }
+
+    @OslcDescription("Descriptive text (reference: Dublin Core) about resource represented as rich text in XHTML content.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "description")
+    @OslcTitle("Description")
+    @OslcValueType(ValueType.XMLLiteral)
+    public String getDescription()
+    {
+        return description;
+    }
+
+    @OslcDescription("Instructions for executing the test script.")
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "executionInstructions")
+    @OslcTitle("Execution Instructions")
+    public URI getExecutionInstructions()
+    {
+        return executionInstructions;
+    }
+
+    @OslcDescription("A related change request.")
+    @OslcName("relatedChangeRequest")
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "relatedChangeRequest")
+    @OslcRange(QmConstants.TYPE_CHANGE_REQUEST)
+    @OslcReadOnly(false)
+    @OslcTitle("Related Change Requests")
+    public Link[] getRelatedChangeRequests()
+    {
+        return relatedChangeRequests.toArray(new Link[relatedChangeRequests.size()]);
+    }
+
+    @OslcDescription("Requirement that is validated by the Test Case.")
+    @OslcName("validatesRequirement")
+    @OslcPropertyDefinition(QmConstants.QUALITY_MANAGEMENT_NAMESPACE + "validatesRequirement")
+    @OslcRange(QmConstants.TYPE_REQUIREMENT)
+    @OslcReadOnly(false)
+    @OslcTitle("Validates Requirement")
+    public Link[] getValidatesRequirements()
+    {
+        return validatesRequirements.toArray(new Link[validatesRequirements.size()]);
+    }
+
+    public void setContributors(final URI[] contributors)
+    {
+        this.contributors.clear();
+
+        if (contributors != null)
+        {
+            this.contributors.addAll(Arrays.asList(contributors));
+        }
+    }
+
+    public void setCreators(final URI[] creators)
+    {
+        this.creators.clear();
+
+        if (creators != null)
+        {
+            this.creators.addAll(Arrays.asList(creators));
+        }
+    }
+
+    public void setDescription(final String description)
+    {
+        this.description = description;
+    }
+
+    public void setExecutionInstructions(final URI executionInstructions)
+    {
+        this.executionInstructions = executionInstructions;
+    }
+
+    public void setRelatedChangeRequests(final Link[] relatedChangeRequests)
+    {
+        this.relatedChangeRequests.clear();
+
+        if (relatedChangeRequests != null)
+        {
+            this.relatedChangeRequests.addAll(Arrays.asList(relatedChangeRequests));
+        }
+    }
+
+    public void setValidatesRequirements(final Link[] validatesRequirements)
+    {
+        this.validatesRequirements.clear();
+
+        if (validatesRequirements != null)
+        {
+            this.validatesRequirements.addAll(Arrays.asList(validatesRequirements));
+        }
+    }
+}


### PR DESCRIPTION
As we discussed earlier, domain spec classes should be moved here from the client repo as well as deprecated where a corresponding generated class exists. Classes I am not sure about deprecating:

- Property
- QmResource

I cannot find a corresponding QmResource class, while the Javadoc for the Property class explains why it is different from the core model class.